### PR TITLE
feat(backend): migrate parser.py → scrapers/ with BaseScraper abstrac…

### DIFF
--- a/backend/app/scrapers/__init__.py
+++ b/backend/app/scrapers/__init__.py
@@ -1,0 +1,1 @@
+from app.scrapers import darkiworld, wawacity  # noqa: F401

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -1,0 +1,56 @@
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_registry: dict[str, type["BaseScraper"]] = {}
+
+
+@dataclass
+class SearchResult:
+    title: str
+    url: str
+    source: str
+    year: int | None = None
+    quality: str | None = None
+    language: str | None = None
+    poster_url: str | None = None
+
+
+@dataclass
+class ProviderLinks:
+    provider: str
+    urls: list[str] = field(default_factory=list)
+
+
+def register(cls: type["BaseScraper"]) -> type["BaseScraper"]:
+    _registry[cls.source_name] = cls
+    logger.debug("Registered scraper: %s", cls.source_name)
+    return cls
+
+
+def get_scraper(source: str) -> "BaseScraper":
+    if source not in _registry:
+        raise KeyError(f"No scraper registered for source: {source!r}")
+    return _registry[source]()
+
+
+class BaseScraper(ABC):
+    source_name: str
+
+    @abstractmethod
+    async def search(
+        self,
+        query: str,
+        category: str,
+        year: int | None = None,
+        limit: int = 10,
+    ) -> list[SearchResult]: ...
+
+    @abstractmethod
+    async def get_provider_links(
+        self,
+        url: str,
+        providers: list[str],
+    ) -> list[ProviderLinks]: ...

--- a/backend/app/scrapers/darkiworld.py
+++ b/backend/app/scrapers/darkiworld.py
@@ -1,0 +1,22 @@
+from app.scrapers.base import BaseScraper, ProviderLinks, SearchResult, register
+
+
+@register
+class DarkiworldScraper(BaseScraper):
+    source_name = "darkiworld"
+
+    async def search(
+        self,
+        query: str,
+        category: str,
+        year: int | None = None,
+        limit: int = 10,
+    ) -> list[SearchResult]:
+        raise NotImplementedError("darkiworld: not implemented yet")
+
+    async def get_provider_links(
+        self,
+        url: str,
+        providers: list[str],
+    ) -> list[ProviderLinks]:
+        raise NotImplementedError("darkiworld: not implemented yet")

--- a/backend/app/scrapers/wawacity.py
+++ b/backend/app/scrapers/wawacity.py
@@ -1,0 +1,208 @@
+import asyncio
+import logging
+import re
+
+import aiohttp
+from bs4 import BeautifulSoup
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.expected_conditions import presence_of_element_located
+from selenium.webdriver.support.wait import WebDriverWait
+from seleniumbase import Driver, SB
+
+from app.config import settings
+from app.scrapers.base import BaseScraper, ProviderLinks, SearchResult, register
+
+logger = logging.getLogger(__name__)
+
+_XPATH_LINK = '//*[@id="protected-container"]/div[2]/div/ul/li/a'
+
+_LANGUAGE_MAP: dict[str, str] = {
+    "FR": "🇫🇷",
+    "EN": "🇬🇧",
+    "VOSTFR": "🇬🇧🇫🇷",
+    "MULTI": "🇪🇺",
+}
+
+_SORT_MAP: dict[str, str] = {
+    "films": "blu-ray_1080p-720p",
+    "series": "vostfr-hq",
+    "mangas": "vostfr-hq",
+}
+
+
+def _match_language(flag_class: str) -> str:
+    lang = flag_class.replace("flag-", "").upper()
+    return _LANGUAGE_MAP.get(lang, "🌐")
+
+
+@register
+class WawacityScraper(BaseScraper):
+    source_name = "wawacity"
+
+    async def search(
+        self,
+        query: str,
+        category: str,
+        year: int | None = None,
+        limit: int = 10,
+    ) -> list[SearchResult]:
+        params: dict[str, str | int] = {
+            "search": query,
+            "p": category,
+            "s": _SORT_MAP.get(category, "vostfr-hq"),
+        }
+        if year is not None:
+            params["year"] = year
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(settings.wawacity_url, params=params) as resp:
+                if resp.status != 200:
+                    logger.error("Wawacity search returned HTTP %d", resp.status)
+                    return []
+                data = await resp.read()
+
+        return self._parse_results(data, limit)
+
+    def _parse_results(self, data: bytes, limit: int) -> list[SearchResult]:
+        pattern = re.compile(r"^(.*?)\s\[(.*?)\]")
+        results: list[SearchResult] = []
+        soup = BeautifulSoup(data, "html.parser")
+        base = settings.wawacity_url.rstrip("/")
+
+        for element in soup.find_all("div", class_="wa-post-detail-item"):
+            if len(results) >= limit:
+                break
+
+            post_title = element.find("div", class_="wa-sub-block-title")
+            if not post_title:
+                continue
+
+            anchor = post_title.find("a")
+            if not anchor:
+                continue
+
+            raw_title = anchor.text
+            m = pattern.match(raw_title)
+            title = m.group(1).strip() if m else raw_title.strip()
+            quality = m.group(2).strip() if m else None
+
+            href = anchor.get("href", "")
+            url = href if href.startswith("http") else f"{base}{href}"
+
+            img = element.find("img")
+            poster_url: str | None = None
+            if img:
+                src = img.get("src", "")
+                poster_url = src if src.startswith("http") else f"{base}{src}"
+
+            year_val: int | None = None
+            year_span = post_title.parent.parent.find("span", string="Année:")
+            if year_span:
+                b = year_span.find_next_sibling("b")
+                if b:
+                    try:
+                        year_val = int(b.text.strip())
+                    except ValueError:
+                        pass
+
+            language: str | None = None
+            flag_i = post_title.find("i")
+            if flag_i:
+                classes = flag_i.get("class") or []
+                if len(classes) > 1:
+                    language = _match_language(classes[1])
+
+            results.append(
+                SearchResult(
+                    title=title,
+                    url=url,
+                    source=self.source_name,
+                    year=year_val,
+                    quality=quality,
+                    language=language,
+                    poster_url=poster_url,
+                )
+            )
+
+        return results
+
+    async def get_provider_links(
+        self,
+        url: str,
+        providers: list[str],
+    ) -> list[ProviderLinks]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, self._fetch_provider_links, url, providers
+        )
+
+    def _fetch_provider_links(
+        self, url: str, providers: list[str]
+    ) -> list[ProviderLinks]:
+        driver = Driver(uc=True, headless=True)
+        try:
+            driver.get(url)
+            logger.debug("Loading provider page: %s", url)
+
+            try:
+                WebDriverWait(driver, 10).until(
+                    presence_of_element_located((By.ID, "main-body"))
+                )
+            except Exception:
+                logger.warning("Timed out waiting for main-body on %s", url)
+                return []
+
+            page_source = driver.page_source
+        finally:
+            driver.quit()
+
+        soup = BeautifulSoup(page_source, "html.parser")
+        table = soup.find("table", id="DDLLinks")
+        if table is None:
+            logger.warning("DDLLinks table not found on %s", url)
+            return []
+
+        grouped: dict[str, list[str]] = {}
+        for tr in table.find_all("tr", class_="link-row"):
+            tds = tr.find_all("td")
+            if len(tds) < 2:
+                continue
+            anchor = tds[0].find("a")
+            if not anchor:
+                continue
+            provider = tds[1].text.strip()
+            if providers and provider not in providers:
+                continue
+            grouped.setdefault(provider, []).append(anchor.get("href", ""))
+
+        return [ProviderLinks(provider=p, urls=urls) for p, urls in grouped.items()]
+
+    async def _resolve_dl_protect(self, url: str) -> str:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._dl_protect_sync, url)
+
+    def _dl_protect_sync(self, url: str) -> str:
+        with SB(uc=True, test=False) as sb:
+            logger.debug("Opening dl-protect: %s", url)
+            sb.driver.uc_open_with_reconnect(url, reconnect_time=20)
+
+            try:
+                sb.driver.switch_to_frame("iframe")
+                sb.driver.uc_click("span")
+            except Exception:
+                logger.warning("Turnstile click failed, retrying")
+                sb.driver.uc_open_with_reconnect(url, reconnect_time=2)
+                sb.driver.switch_to_frame("iframe")
+                sb.driver.uc_click("span")
+
+            sb.highlight_click('button:contains("Continuer")')
+
+            try:
+                link = sb.find_element(By.XPATH, _XPATH_LINK)
+                href = link.get_attribute("href")
+                logger.debug("Resolved dl-protect → %s", href)
+                return href
+            except Exception as exc:
+                raise RuntimeError(
+                    f"dl_protect resolution failed for {url}"
+                ) from exc

--- a/backend/tests/test_scrapers.py
+++ b/backend/tests/test_scrapers.py
@@ -1,0 +1,214 @@
+import pytest
+
+import app.scrapers  # noqa: F401 — triggers @register decorators
+from app.scrapers.base import ProviderLinks, SearchResult, get_scraper
+from app.scrapers.darkiworld import DarkiworldScraper
+from app.scrapers.wawacity import WawacityScraper
+
+# ---------------------------------------------------------------------------
+# Minimal HTML fixture that matches the wawacity page structure
+# ---------------------------------------------------------------------------
+
+_WAWACITY_HTML = """
+<html><body>
+<div class="wa-post-detail-item">
+  <img src="/img/inception.jpg">
+  <div class="wa-sub-block">
+    <div>
+      <div class="wa-sub-block-title">
+        <a href="/?p=films&amp;id=1-inception">Inception [BLU-RAY 1080p]
+          <i class="flag-icon flag-fr"></i>
+        </a>
+      </div>
+      <span>Ann\u00e9e:</span><b>2010</b>
+    </div>
+  </div>
+</div>
+<div class="wa-post-detail-item">
+  <img src="/img/dune.jpg">
+  <div class="wa-sub-block">
+    <div>
+      <div class="wa-sub-block-title">
+        <a href="/?p=films&amp;id=2-dune">Dune [WEB-DL 4K]
+          <i class="flag-icon flag-multi"></i>
+        </a>
+      </div>
+      <span>Ann\u00e9e:</span><b>2021</b>
+    </div>
+  </div>
+</div>
+</body></html>
+""".encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_get_scraper_wawacity():
+    scraper = get_scraper("wawacity")
+    assert isinstance(scraper, WawacityScraper)
+
+
+def test_get_scraper_darkiworld():
+    scraper = get_scraper("darkiworld")
+    assert isinstance(scraper, DarkiworldScraper)
+
+
+def test_get_scraper_unknown_raises():
+    with pytest.raises(KeyError, match="unknown_source"):
+        get_scraper("unknown_source")
+
+
+# ---------------------------------------------------------------------------
+# WawacityScraper._parse_results
+# ---------------------------------------------------------------------------
+
+
+def test_parse_results_returns_search_results():
+    scraper = WawacityScraper()
+    results = scraper._parse_results(_WAWACITY_HTML, limit=10)
+
+    assert len(results) == 2
+    assert all(isinstance(r, SearchResult) for r in results)
+
+
+def test_parse_results_extracts_title_and_quality():
+    scraper = WawacityScraper()
+    results = scraper._parse_results(_WAWACITY_HTML, limit=10)
+
+    assert results[0].title == "Inception"
+    assert results[0].quality == "BLU-RAY 1080p"
+    assert results[1].title == "Dune"
+    assert results[1].quality == "WEB-DL 4K"
+
+
+def test_parse_results_extracts_year():
+    scraper = WawacityScraper()
+    results = scraper._parse_results(_WAWACITY_HTML, limit=10)
+
+    assert results[0].year == 2010
+    assert results[1].year == 2021
+
+
+def test_parse_results_extracts_language():
+    scraper = WawacityScraper()
+    results = scraper._parse_results(_WAWACITY_HTML, limit=10)
+
+    assert results[0].language == "🇫🇷"
+    assert results[1].language == "🇪🇺"
+
+
+def test_parse_results_sets_source():
+    scraper = WawacityScraper()
+    results = scraper._parse_results(_WAWACITY_HTML, limit=10)
+
+    assert all(r.source == "wawacity" for r in results)
+
+
+def test_parse_results_respects_limit():
+    scraper = WawacityScraper()
+    results = scraper._parse_results(_WAWACITY_HTML, limit=1)
+
+    assert len(results) == 1
+
+
+def test_parse_results_empty_html():
+    scraper = WawacityScraper()
+    results = scraper._parse_results("<html><body></body></html>".encode(), limit=10)
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# WawacityScraper.search — mock aiohttp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_returns_results(monkeypatch):
+    import aiohttp
+
+    class FakeResponse:
+        status = 200
+
+        async def read(self):
+            return _WAWACITY_HTML
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def get(self, *args, **kwargs):
+            return FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: FakeSession())
+
+    scraper = WawacityScraper()
+    results = await scraper.search("inception", "films", limit=10)
+
+    assert len(results) == 2
+    assert results[0].title == "Inception"
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_http_error(monkeypatch):
+    import aiohttp
+
+    class FakeResponse:
+        status = 503
+
+        async def read(self):
+            return b""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def get(self, *args, **kwargs):
+            return FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: FakeSession())
+
+    scraper = WawacityScraper()
+    results = await scraper.search("inception", "films")
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# DarkiworldScraper stubs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_darkiworld_search_raises_not_implemented():
+    scraper = DarkiworldScraper()
+    with pytest.raises(NotImplementedError):
+        await scraper.search("test", "films")
+
+
+@pytest.mark.asyncio
+async def test_darkiworld_get_provider_links_raises_not_implemented():
+    scraper = DarkiworldScraper()
+    with pytest.raises(NotImplementedError):
+        await scraper.get_provider_links("https://example.com", [])


### PR DESCRIPTION
…tion (issue #33)

- Add BaseScraper ABC with SearchResult + ProviderLinks dataclasses and @register registry
- Implement WawacityScraper: search() from bot.py, get_provider_links() + _resolve_dl_protect() from parser.py (Selenium wrapped in run_in_executor)
- Add DarkiworldScraper stub raising NotImplementedError
- Auto-register scrapers via scrapers/__init__.py imports
- Add 14 unit tests covering registry, HTML parsing, search mocking, and stubs