### PR TITLE
feat(backend): async AllDebridClient with aiohttp (issue #34)

### DIFF
--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,0 +1,18 @@
+class AllDebridError(Exception):
+    """Base exception for AllDebrid API errors."""
+
+
+class AllDebridAPIError(AllDebridError):
+    """Raised when the AllDebrid API returns an error status."""
+
+    def __init__(self, message: str, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class AllDebridHTTPError(AllDebridError):
+    """Raised when the HTTP request to AllDebrid fails."""
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"HTTP error {status}")
+        self.status = status

--- a/backend/app/services/alldebrid.py
+++ b/backend/app/services/alldebrid.py
@@ -1,0 +1,56 @@
+import aiohttp
+
+from app.config import settings
+from app.core.exceptions import AllDebridAPIError, AllDebridHTTPError
+
+_BASE_URL = "https://api.alldebrid.com/v4"
+_AGENT = "AlldebridBot"
+
+
+class AllDebridClient:
+    def __init__(self) -> None:
+        self._api_key = settings.alldebrid_api_key
+
+    def _base_params(self) -> dict[str, str]:
+        return {"agent": _AGENT, "apikey": self._api_key}
+
+    async def redirect_link(self, url: str) -> str:
+        """Resolve a redirect/protection link and return the direct URL."""
+        params = {**self._base_params(), "link": url}
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{_BASE_URL}/link/redirector", params=params
+            ) as response:
+                if response.status != 200:
+                    raise AllDebridHTTPError(response.status)
+                data = await response.json()
+
+        if data["status"] == "error":
+            error = data.get("error", {})
+            raise AllDebridAPIError(
+                error.get("message", "Unknown error"), error.get("code")
+            )
+
+        return data["data"]["links"][0]
+
+    async def debrid_link(self, url: str) -> dict:
+        """Unlock a link via AllDebrid and return the unlock data."""
+        if "dl-protect" in url:
+            url = await self.redirect_link(url)
+
+        params = {**self._base_params(), "link": url}
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{_BASE_URL}/link/unlock", params=params
+            ) as response:
+                if response.status != 200:
+                    raise AllDebridHTTPError(response.status)
+                data = await response.json()
+
+        if data["status"] == "error":
+            error = data.get("error", {})
+            raise AllDebridAPIError(
+                error.get("message", "Unknown error"), error.get("code")
+            )
+
+        return data["data"]

--- a/backend/tests/test_alldebrid.py
+++ b/backend/tests/test_alldebrid.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.exceptions import AllDebridAPIError, AllDebridHTTPError
+from app.services.alldebrid import AllDebridClient
+
+
+def _mock_response(status: int, json_data: dict) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
+
+
+def _mock_session(response: MagicMock) -> MagicMock:
+    session = MagicMock()
+    session.get = MagicMock(return_value=response)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+@pytest.fixture
+def client():
+    return AllDebridClient()
+
+
+class TestRedirectLink:
+    async def test_returns_direct_url(self, client: AllDebridClient) -> None:
+        payload = {"status": "success", "data": {"links": ["https://direct.example.com/file.mkv"]}}
+        session = _mock_session(_mock_response(200, payload))
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            result = await client.redirect_link("https://dl-protect.link/abc")
+
+        assert result == "https://direct.example.com/file.mkv"
+
+    async def test_raises_on_http_error(self, client: AllDebridClient) -> None:
+        session = _mock_session(_mock_response(503, {}))
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            with pytest.raises(AllDebridHTTPError) as exc_info:
+                await client.redirect_link("https://dl-protect.link/abc")
+
+        assert exc_info.value.status == 503
+
+    async def test_raises_on_api_error(self, client: AllDebridClient) -> None:
+        payload = {"status": "error", "error": {"message": "Invalid link", "code": "LINK_ERROR"}}
+        session = _mock_session(_mock_response(200, payload))
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            with pytest.raises(AllDebridAPIError) as exc_info:
+                await client.redirect_link("https://dl-protect.link/abc")
+
+        assert "Invalid link" in str(exc_info.value)
+        assert exc_info.value.code == "LINK_ERROR"
+
+
+class TestDebridLink:
+    async def test_unlocks_direct_link(self, client: AllDebridClient) -> None:
+        payload = {"status": "success", "data": {"link": "https://cdn.example.com/file.mkv", "filename": "file.mkv"}}
+        session = _mock_session(_mock_response(200, payload))
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            result = await client.debrid_link("https://1fichier.com/?abc123")
+
+        assert result["filename"] == "file.mkv"
+
+    async def test_resolves_redirect_before_unlock(self, client: AllDebridClient) -> None:
+        redirect_payload = {"status": "success", "data": {"links": ["https://1fichier.com/?abc123"]}}
+        unlock_payload = {"status": "success", "data": {"link": "https://cdn.example.com/file.mkv"}}
+
+        redirect_response = _mock_response(200, redirect_payload)
+        unlock_response = _mock_response(200, unlock_payload)
+
+        call_count = 0
+
+        def get_side_effect(url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return redirect_response if call_count == 1 else unlock_response
+
+        session = MagicMock()
+        session.get = MagicMock(side_effect=get_side_effect)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            result = await client.debrid_link("https://dl-protect.link/abc")
+
+        assert result["link"] == "https://cdn.example.com/file.mkv"
+
+    async def test_raises_on_http_error(self, client: AllDebridClient) -> None:
+        session = _mock_session(_mock_response(401, {}))
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            with pytest.raises(AllDebridHTTPError) as exc_info:
+                await client.debrid_link("https://1fichier.com/?abc123")
+
+        assert exc_info.value.status == 401
+
+    async def test_raises_on_api_error(self, client: AllDebridClient) -> None:
+        payload = {"status": "error", "error": {"message": "Locked link", "code": "LINK_LOCKED"}}
+        session = _mock_session(_mock_response(200, payload))
+
+        with patch("app.services.alldebrid.aiohttp.ClientSession", return_value=session):
+            with pytest.raises(AllDebridAPIError) as exc_info:
+                await client.debrid_link("https://1fichier.com/?abc123")
+
+        assert exc_info.value.code == "LINK_LOCKED"


### PR DESCRIPTION
## Summary

- Réécriture complète de `alldebrid.py` en async avec `aiohttp` (suppression de `requests`)
- Nouvelle classe `AllDebridClient` dans `backend/app/services/alldebrid.py`
- Exceptions typées dans `backend/app/core/exceptions.py` : `AllDebridAPIError` et `AllDebridHTTPError`
- 7 tests unitaires couvrant les cas nominaux et d'erreur

## Test plan

- [x] `test_returns_direct_url` — redirect_link retourne l'URL directe
- [x] `test_raises_on_http_error` — HTTP 503/401 lève `AllDebridHTTPError`
- [x] `test_raises_on_api_error` — réponse API error lève `AllDebridAPIError` avec code
- [x] `test_unlocks_direct_link` — debrid_link retourne les données unlock
- [x] `test_resolves_redirect_before_unlock` — dl-protect déclenche redirect_link avant unlock
- [x] 43/43 tests backend passent

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)