### PR TITLE
feat(backend): download_service.py avec DownloadQueue asyncio (issue #35)

### DIFF
--- a/backend/app/core/events.py
+++ b/backend/app/core/events.py
@@ -1,0 +1,27 @@
+import asyncio
+from collections import defaultdict
+
+_subscribers: dict[str, list[asyncio.Queue]] = defaultdict(list)
+
+
+def subscribe(download_id: str) -> asyncio.Queue:
+    """Register a new listener for a download and return its queue."""
+    q: asyncio.Queue = asyncio.Queue()
+    _subscribers[download_id].append(q)
+    return q
+
+
+def unsubscribe(download_id: str, queue: asyncio.Queue) -> None:
+    """Remove a listener. Cleans up the entry when no listeners remain."""
+    try:
+        _subscribers[download_id].remove(queue)
+    except ValueError:
+        pass
+    if not _subscribers[download_id]:
+        _subscribers.pop(download_id, None)
+
+
+async def emit(download_id: str, event: dict) -> None:
+    """Push an event to all listeners subscribed to this download."""
+    for q in list(_subscribers.get(download_id, [])):
+        await q.put(event)

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -16,3 +16,15 @@ class AllDebridHTTPError(AllDebridError):
     def __init__(self, status: int) -> None:
         super().__init__(f"HTTP error {status}")
         self.status = status
+
+
+class DownloadError(Exception):
+    """Raised when a download fails."""
+
+
+class DownloadNotFoundError(DownloadError):
+    """Raised when a download ID does not exist in the database."""
+
+    def __init__(self, download_id: str) -> None:
+        super().__init__(f"Download not found: {download_id}")
+        self.download_id = download_id

--- a/backend/app/core/queue.py
+++ b/backend/app/core/queue.py
@@ -1,0 +1,65 @@
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_Handler = Callable[[str], Awaitable[None]]
+
+
+class DownloadQueue:
+    """Asyncio-based download queue with a configurable worker pool."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+        self._workers: list[asyncio.Task] = []
+        self._handler: _Handler | None = None
+
+    def set_handler(self, handler: _Handler) -> None:
+        """Set the coroutine that processes each download_id."""
+        self._handler = handler
+
+    async def enqueue(self, download_id: str) -> None:
+        """Add a download job to the queue."""
+        await self._queue.put(download_id)
+        logger.debug("Enqueued download %s (queue size: %d)", download_id, self._queue.qsize())
+
+    async def _worker(self) -> None:
+        while True:
+            download_id = await self._queue.get()
+            try:
+                if self._handler is not None:
+                    await self._handler(download_id)
+            except Exception:
+                logger.exception("Unhandled error while processing download %s", download_id)
+            finally:
+                self._queue.task_done()
+
+    def start(self) -> None:
+        """Spawn worker tasks. Call once from the FastAPI lifespan."""
+        n = settings.max_concurrent_downloads
+        for _ in range(n):
+            task = asyncio.create_task(self._worker())
+            self._workers.append(task)
+        logger.info("DownloadQueue started with %d worker(s)", n)
+
+    async def stop(self) -> None:
+        """Cancel all workers and wait for them to finish."""
+        for task in self._workers:
+            task.cancel()
+        await asyncio.gather(*self._workers, return_exceptions=True)
+        self._workers.clear()
+        logger.info("DownloadQueue stopped")
+
+    @property
+    def size(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def active(self) -> int:
+        return sum(1 for t in self._workers if not t.done())
+
+
+download_queue = DownloadQueue()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,14 +3,25 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.database import Base, engine
+from app.core.queue import download_queue
+from app.database import Base, AsyncSessionLocal, engine
+from app.services.download_service import DownloadService
+
+
+async def _run_download(download_id: str) -> None:
+    async with AsyncSessionLocal() as session:
+        service = DownloadService(session)
+        await service.run(download_id)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    download_queue.set_handler(_run_download)
+    download_queue.start()
     yield
+    await download_queue.stop()
     await engine.dispose()
 
 

--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -1,0 +1,224 @@
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiohttp
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.core import events
+from app.core.exceptions import DownloadError, DownloadNotFoundError
+from app.models.orm import Download, History
+from app.models.schemas import DownloadCreate, WsProgressEvent
+from app.services.alldebrid import AllDebridClient
+
+logger = logging.getLogger(__name__)
+
+_CHUNK_SIZE = 64 * 1024  # 64 KB
+_DB_UPDATE_INTERVAL = 2.0  # seconds between DB writes during streaming
+_WS_EMIT_INTERVAL = 0.5  # seconds between WebSocket events during streaming
+
+
+class DownloadService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._alldebrid = AllDebridClient()
+
+    # ------------------------------------------------------------------
+    # CRUD helpers
+    # ------------------------------------------------------------------
+
+    async def create(self, data: DownloadCreate) -> Download:
+        download = Download(
+            title=data.title,
+            source_url=str(data.source_url),
+            media_type=data.media_type,
+            destination=data.destination,
+            status="queued",
+        )
+        self._session.add(download)
+        await self._session.commit()
+        await self._session.refresh(download)
+        logger.info("Created download %s (%s)", download.id, download.title)
+        return download
+
+    async def get(self, download_id: str) -> Download | None:
+        return await self._session.get(Download, download_id)
+
+    async def list_active(self) -> list[Download]:
+        result = await self._session.execute(
+            select(Download).where(Download.status.in_(["queued", "downloading"]))
+        )
+        return list(result.scalars().all())
+
+    async def delete(self, download_id: str) -> bool:
+        download = await self.get(download_id)
+        if download is None:
+            return False
+        await self._session.delete(download)
+        await self._session.commit()
+        return True
+
+    # ------------------------------------------------------------------
+    # Download execution
+    # ------------------------------------------------------------------
+
+    async def run(self, download_id: str) -> None:
+        """Debrid + download a queued job. Called by the queue worker."""
+        download = await self.get(download_id)
+        if download is None:
+            raise DownloadNotFoundError(download_id)
+
+        try:
+            await self._set_status(download, "downloading")
+            await events.emit(
+                download_id,
+                WsProgressEvent(
+                    download_id=download_id, status="downloading", progress_pct=0.0
+                ).model_dump(),
+            )
+
+            debrid_data = await self._alldebrid.debrid_link(download.source_url)
+            direct_url: str | None = debrid_data.get("link") or (
+                debrid_data.get("links") or [None]
+            )[0]
+            if not direct_url:
+                raise DownloadError("AllDebrid returned no direct URL")
+
+            filename: str | None = debrid_data.get("filename") or Path(direct_url).name
+
+            if download.destination == "client":
+                await self._set_status(
+                    download,
+                    "completed",
+                    progress_pct=100.0,
+                    filename=filename,
+                    completed_at=datetime.now(UTC),
+                )
+                await events.emit(
+                    download_id,
+                    WsProgressEvent(
+                        download_id=download_id,
+                        status="completed",
+                        progress_pct=100.0,
+                        filename=filename,
+                    ).model_dump(),
+                )
+                return
+
+            # Server-side streaming download
+            await self._stream_to_disk(download, direct_url, filename)
+            await self._write_history(download, filename)
+
+        except Exception as exc:
+            await self._set_status(download, "error", error=str(exc))
+            await events.emit(
+                download_id,
+                WsProgressEvent(
+                    download_id=download_id,
+                    status="error",
+                    progress_pct=download.progress_pct,
+                ).model_dump(),
+            )
+            logger.exception("Download %s failed", download_id)
+            raise
+
+    async def _stream_to_disk(
+        self, download: Download, url: str, filename: str
+    ) -> None:
+        dest = Path(settings.download_path) / filename
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        download_id = download.id
+        loop = asyncio.get_event_loop()
+        start = time.monotonic()
+        downloaded = 0
+        last_db_update = start
+        last_ws_emit = start
+
+        async with aiohttp.ClientSession() as http:
+            async with http.get(url) as response:
+                if response.status != 200:
+                    raise DownloadError(f"HTTP {response.status} when fetching {url}")
+
+                total = int(response.headers.get("Content-Length", 0))
+                f = await loop.run_in_executor(None, open, str(dest), "wb")
+                try:
+                    async for chunk in response.content.iter_chunked(_CHUNK_SIZE):
+                        await loop.run_in_executor(None, f.write, chunk)
+                        downloaded += len(chunk)
+
+                        now = time.monotonic()
+                        elapsed = now - start
+                        speed_bps = downloaded / elapsed if elapsed > 0 else 0.0
+                        progress = (downloaded / total * 100.0) if total else 0.0
+                        speed_mbps = speed_bps / 1_000_000
+                        eta_s = (
+                            int((total - downloaded) / speed_bps)
+                            if speed_bps and total
+                            else None
+                        )
+
+                        if now - last_ws_emit >= _WS_EMIT_INTERVAL:
+                            await events.emit(
+                                download_id,
+                                WsProgressEvent(
+                                    download_id=download_id,
+                                    status="downloading",
+                                    progress_pct=progress,
+                                    speed_mbps=speed_mbps,
+                                    eta_s=eta_s,
+                                    filename=filename,
+                                ).model_dump(),
+                            )
+                            last_ws_emit = now
+
+                        if now - last_db_update >= _DB_UPDATE_INTERVAL:
+                            await self._set_status(
+                                download,
+                                "downloading",
+                                progress_pct=progress,
+                                speed_mbps=speed_mbps,
+                                filename=filename,
+                            )
+                            last_db_update = now
+                finally:
+                    await loop.run_in_executor(None, f.close)
+
+        await self._set_status(
+            download,
+            "completed",
+            progress_pct=100.0,
+            filename=filename,
+            completed_at=datetime.now(UTC),
+        )
+        await events.emit(
+            download_id,
+            WsProgressEvent(
+                download_id=download_id,
+                status="completed",
+                progress_pct=100.0,
+                filename=filename,
+            ).model_dump(),
+        )
+        logger.info("Download %s completed → %s", download_id, dest)
+
+    async def _write_history(self, download: Download, filename: str | None) -> None:
+        history = History(
+            title=download.title,
+            source_url=download.source_url,
+            filename=filename,
+            media_type=download.media_type,
+            source="alldebrid",
+        )
+        self._session.add(history)
+        await self._session.commit()
+
+    async def _set_status(self, download: Download, status: str, **kwargs) -> None:
+        download.status = status
+        for key, value in kwargs.items():
+            setattr(download, key, value)
+        await self._session.commit()

--- a/backend/tests/test_download_service.py
+++ b/backend/tests/test_download_service.py
@@ -1,0 +1,205 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core import events
+from app.core.exceptions import DownloadError, DownloadNotFoundError
+from app.models.orm import Download
+from app.models.schemas import DownloadCreate
+from app.services.download_service import DownloadService
+
+
+@pytest.fixture
+def service(db_session):
+    return DownloadService(db_session)
+
+
+@pytest.fixture
+def download_create() -> DownloadCreate:
+    return DownloadCreate(
+        source_url="https://1fichier.com/?abc123",
+        title="Test Movie",
+        media_type="movie",
+        destination="server",
+    )
+
+
+class TestCreate:
+    async def test_creates_record_with_queued_status(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        download = await service.create(download_create)
+
+        assert download.id is not None
+        assert download.title == "Test Movie"
+        assert download.status == "queued"
+        assert download.progress_pct == 0.0
+        assert download.destination == "server"
+
+    async def test_persists_to_db(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        download = await service.create(download_create)
+        fetched = await service.get(download.id)
+
+        assert fetched is not None
+        assert fetched.id == download.id
+
+
+class TestGet:
+    async def test_returns_none_for_unknown_id(self, service: DownloadService) -> None:
+        result = await service.get("nonexistent-id")
+        assert result is None
+
+    async def test_returns_download_by_id(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        created = await service.create(download_create)
+        result = await service.get(created.id)
+
+        assert result is not None
+        assert result.id == created.id
+
+
+class TestDelete:
+    async def test_returns_false_for_unknown_id(self, service: DownloadService) -> None:
+        result = await service.delete("nonexistent-id")
+        assert result is False
+
+    async def test_deletes_existing_download(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        download = await service.create(download_create)
+        result = await service.delete(download.id)
+
+        assert result is True
+        assert await service.get(download.id) is None
+
+
+class TestListActive:
+    async def test_returns_queued_and_downloading(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        d1 = await service.create(download_create)
+        d2 = await service.create(download_create)
+        await service._set_status(d2, "downloading")
+
+        active = await service.list_active()
+        ids = {d.id for d in active}
+
+        assert d1.id in ids
+        assert d2.id in ids
+
+    async def test_excludes_completed_and_error(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        d = await service.create(download_create)
+        await service._set_status(d, "completed")
+
+        active = await service.list_active()
+        assert not any(x.id == d.id for x in active)
+
+
+class TestRunClientDestination:
+    async def test_client_destination_emits_completed_without_downloading(
+        self, service: DownloadService, db_session
+    ) -> None:
+        data = DownloadCreate(
+            source_url="https://1fichier.com/?abc123",
+            title="Film",
+            media_type="movie",
+            destination="client",
+        )
+        download = await service.create(data)
+
+        debrid_data = {"link": "https://cdn.example.com/film.mkv", "filename": "film.mkv"}
+        emitted: list[dict] = []
+
+        async def capture_emit(download_id: str, event: dict) -> None:
+            emitted.append(event)
+
+        with (
+            patch.object(service._alldebrid, "debrid_link", new=AsyncMock(return_value=debrid_data)),
+            patch("app.services.download_service.events.emit", side_effect=capture_emit),
+        ):
+            await service.run(download.id)
+
+        refreshed = await service.get(download.id)
+        assert refreshed is not None
+        assert refreshed.status == "completed"
+        assert refreshed.progress_pct == 100.0
+        assert refreshed.filename == "film.mkv"
+
+        completed_event = next(e for e in emitted if e["status"] == "completed")
+        assert completed_event["download_id"] == download.id
+
+    async def test_client_destination_never_writes_to_disk(
+        self, service: DownloadService
+    ) -> None:
+        data = DownloadCreate(
+            source_url="https://1fichier.com/?abc123",
+            title="Film",
+            media_type="movie",
+            destination="client",
+        )
+        download = await service.create(data)
+
+        debrid_data = {"link": "https://cdn.example.com/film.mkv", "filename": "film.mkv"}
+
+        with (
+            patch.object(service._alldebrid, "debrid_link", new=AsyncMock(return_value=debrid_data)),
+            patch("app.services.download_service.events.emit", new=AsyncMock()),
+            patch("builtins.open") as mock_open,
+        ):
+            await service.run(download.id)
+            mock_open.assert_not_called()
+
+
+class TestRunErrors:
+    async def test_raises_download_not_found_for_unknown_id(
+        self, service: DownloadService
+    ) -> None:
+        with pytest.raises(DownloadNotFoundError):
+            await service.run("nonexistent-id")
+
+    async def test_sets_error_status_on_alldebrid_failure(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        download = await service.create(download_create)
+
+        with (
+            patch.object(
+                service._alldebrid,
+                "debrid_link",
+                new=AsyncMock(side_effect=DownloadError("AllDebrid failed")),
+            ),
+            patch("app.services.download_service.events.emit", new=AsyncMock()),
+            pytest.raises(DownloadError),
+        ):
+            await service.run(download.id)
+
+        refreshed = await service.get(download.id)
+        assert refreshed is not None
+        assert refreshed.status == "error"
+        assert "AllDebrid failed" in (refreshed.error or "")
+
+    async def test_sets_error_when_no_direct_url(
+        self, service: DownloadService, download_create: DownloadCreate
+    ) -> None:
+        download = await service.create(download_create)
+
+        with (
+            patch.object(
+                service._alldebrid,
+                "debrid_link",
+                new=AsyncMock(return_value={"link": None, "links": []}),
+            ),
+            patch("app.services.download_service.events.emit", new=AsyncMock()),
+            pytest.raises(DownloadError),
+        ):
+            await service.run(download.id)
+
+        refreshed = await service.get(download.id)
+        assert refreshed is not None
+        assert refreshed.status == "error"

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+
+from app.core import events
+
+
+@pytest.fixture(autouse=True)
+def clear_subscribers():
+    events._subscribers.clear()
+    yield
+    events._subscribers.clear()
+
+
+class TestEvents:
+    async def test_subscribe_returns_queue(self) -> None:
+        q = events.subscribe("dl-1")
+        assert isinstance(q, asyncio.Queue)
+
+    async def test_emit_delivers_to_subscriber(self) -> None:
+        q = events.subscribe("dl-1")
+        await events.emit("dl-1", {"status": "downloading"})
+        event = q.get_nowait()
+        assert event["status"] == "downloading"
+
+    async def test_emit_delivers_to_multiple_subscribers(self) -> None:
+        q1 = events.subscribe("dl-1")
+        q2 = events.subscribe("dl-1")
+        await events.emit("dl-1", {"status": "completed"})
+        assert q1.get_nowait()["status"] == "completed"
+        assert q2.get_nowait()["status"] == "completed"
+
+    async def test_emit_does_not_deliver_to_other_download(self) -> None:
+        q = events.subscribe("dl-2")
+        await events.emit("dl-1", {"status": "downloading"})
+        assert q.empty()
+
+    async def test_unsubscribe_removes_queue(self) -> None:
+        q = events.subscribe("dl-1")
+        events.unsubscribe("dl-1", q)
+        await events.emit("dl-1", {"status": "completed"})
+        assert q.empty()
+
+    async def test_unsubscribe_cleans_up_empty_entry(self) -> None:
+        q = events.subscribe("dl-1")
+        events.unsubscribe("dl-1", q)
+        assert "dl-1" not in events._subscribers
+
+    async def test_unsubscribe_tolerates_unknown_queue(self) -> None:
+        q: asyncio.Queue = asyncio.Queue()
+        events.unsubscribe("nonexistent", q)  # must not raise

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -1,0 +1,57 @@
+import asyncio
+
+import pytest
+
+from app.core.queue import DownloadQueue
+
+
+class TestDownloadQueue:
+    async def test_enqueue_increments_size(self) -> None:
+        q = DownloadQueue()
+        await q.enqueue("dl-1")
+        await q.enqueue("dl-2")
+        assert q.size == 2
+
+    async def test_worker_calls_handler(self) -> None:
+        q = DownloadQueue()
+        processed: list[str] = []
+
+        async def handler(download_id: str) -> None:
+            processed.append(download_id)
+
+        q.set_handler(handler)
+        q.start()
+
+        await q.enqueue("dl-abc")
+        await asyncio.sleep(0.05)
+
+        assert "dl-abc" in processed
+
+        await q.stop()
+
+    async def test_stop_cancels_workers(self) -> None:
+        q = DownloadQueue()
+        q.start()
+        assert q.active > 0
+        await q.stop()
+        assert q.active == 0
+
+    async def test_handler_exception_does_not_kill_worker(self) -> None:
+        q = DownloadQueue()
+        processed: list[str] = []
+
+        async def handler(download_id: str) -> None:
+            if download_id == "bad":
+                raise RuntimeError("intentional error")
+            processed.append(download_id)
+
+        q.set_handler(handler)
+        q.start()
+
+        await q.enqueue("bad")
+        await q.enqueue("good")
+        await asyncio.sleep(0.1)
+
+        assert "good" in processed
+
+        await q.stop()


### PR DESCRIPTION
## Summary

- **`DownloadService`** (`services/download_service.py`) — create/get/delete/list_active + `run()` : debrid via AllDebrid → stream vers disque avec progression → mise à jour DB + événements WebSocket
- **`DownloadQueue`** (`core/queue.py`) — pool de workers asyncio limité à `max_concurrent_downloads`, handler injecté depuis le lifespan FastAPI
- **`events.py`** (`core/events.py`) — bus d'événements WebSocket : `subscribe / unsubscribe / emit` (dict `download_id → list[asyncio.Queue]`)
- Lifespan FastAPI démarré/stoppé proprement avec la queue
- Throttling DB (2 s) et WS (0,5 s) pendant le streaming pour éviter les flush inutiles

## Test plan

- [ ] 24 tests unitaires : `test_events.py`, `test_queue.py`, `test_download_service.py`
- [ ] Passe la suite complète (67 tests) sans régression

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)