### PR TITLE
feat(backend): endpoints REST FastAPI + WebSocket progression (issue #36)

### DIFF
--- a/backend/app/api/v1/downloads.py
+++ b/backend/app/api/v1/downloads.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.queue import download_queue
+from app.database import get_db
+from app.models.schemas import DownloadCreate, DownloadCreated, DownloadRead
+from app.services.download_service import DownloadService
+
+router = APIRouter()
+
+
+@router.post("/downloads", response_model=DownloadCreated, status_code=201)
+async def create_download(
+    data: DownloadCreate,
+    session: AsyncSession = Depends(get_db),
+) -> DownloadCreated:
+    service = DownloadService(session)
+    download = await service.create(data)
+    await download_queue.enqueue(download.id)
+    return DownloadCreated(download_id=download.id, status=download.status)
+
+
+@router.get("/downloads", response_model=list[DownloadRead])
+async def list_downloads(
+    session: AsyncSession = Depends(get_db),
+) -> list[DownloadRead]:
+    service = DownloadService(session)
+    return await service.list_active()  # type: ignore[return-value]
+
+
+@router.get("/downloads/{download_id}", response_model=DownloadRead)
+async def get_download(
+    download_id: str,
+    session: AsyncSession = Depends(get_db),
+) -> DownloadRead:
+    service = DownloadService(session)
+    download = await service.get(download_id)
+    if download is None:
+        raise HTTPException(status_code=404, detail="Download not found")
+    return download  # type: ignore[return-value]
+
+
+@router.delete("/downloads/{download_id}", status_code=204)
+async def delete_download(
+    download_id: str,
+    session: AsyncSession = Depends(get_db),
+) -> None:
+    service = DownloadService(session)
+    deleted = await service.delete(download_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Download not found")

--- a/backend/app/api/v1/history.py
+++ b/backend/app/api/v1/history.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.orm import History
+from app.models.schemas import HistoryList, HistoryRead
+
+router = APIRouter()
+
+
+@router.get("/history", response_model=HistoryList)
+async def list_history(
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+    q: str | None = Query(None, description="Filter by title"),
+    session: AsyncSession = Depends(get_db),
+) -> HistoryList:
+    base_query = select(History)
+    if q:
+        base_query = base_query.where(History.title.ilike(f"%{q}%"))
+
+    count_result = await session.execute(
+        select(func.count()).select_from(base_query.subquery())
+    )
+    total = count_result.scalar_one()
+
+    rows = await session.execute(
+        base_query.order_by(History.downloaded_at.desc())
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    items = list(rows.scalars().all())
+
+    return HistoryList(
+        items=[HistoryRead.model_validate(h) for h in items],
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.delete("/history/{history_id}", status_code=204)
+async def delete_history(
+    history_id: str,
+    session: AsyncSession = Depends(get_db),
+) -> None:
+    entry = await session.get(History, history_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="History entry not found")
+    await session.delete(entry)
+    await session.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+from app.api.v1 import downloads, history, search, settings, status
+
+router = APIRouter(prefix="/api/v1")
+
+router.include_router(search.router)
+router.include_router(downloads.router)
+router.include_router(history.router)
+router.include_router(settings.router)
+router.include_router(status.router)

--- a/backend/app/api/v1/search.py
+++ b/backend/app/api/v1/search.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.schemas import SearchResponse
+from app.models.schemas import SearchResult as SearchResultSchema
+from app.scrapers.base import get_scraper
+
+router = APIRouter()
+
+
+@router.get("/search", response_model=SearchResponse)
+async def search(
+    q: str = Query(..., min_length=1, description="Search query"),
+    source: str = Query("wawacity", description="Scraper source"),
+    category: str = Query("films", description="Content category"),
+    year: int | None = Query(None, description="Release year filter"),
+    limit: int = Query(10, ge=1, le=50),
+) -> SearchResponse:
+    try:
+        scraper = get_scraper(source)
+    except KeyError:
+        raise HTTPException(status_code=400, detail=f"Unknown source: {source!r}")
+
+    raw = await scraper.search(q, category, year, limit)
+
+    results = [
+        SearchResultSchema(
+            title=r.title,
+            url=r.url,
+            year=r.year,
+            category=category,
+            quality=r.quality,
+            language=r.language,
+            source=r.source,
+            poster_url=r.poster_url,
+        )
+        for r in raw
+    ]
+    return SearchResponse(results=results, total=len(results), source=source)

--- a/backend/app/api/v1/search.py
+++ b/backend/app/api/v1/search.py
@@ -20,7 +20,10 @@ async def search(
     except KeyError:
         raise HTTPException(status_code=400, detail=f"Unknown source: {source!r}")
 
-    raw = await scraper.search(q, category, year, limit)
+    try:
+        raw = await scraper.search(q, category, year, limit)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Scraper error: {exc}") from exc
 
     results = [
         SearchResultSchema(

--- a/backend/app/api/v1/settings.py
+++ b/backend/app/api/v1/settings.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.orm import Setting
+from app.models.schemas import SettingRead, SettingsUpdate
+
+router = APIRouter()
+
+
+@router.get("/settings", response_model=list[SettingRead])
+async def get_settings(
+    session: AsyncSession = Depends(get_db),
+) -> list[SettingRead]:
+    result = await session.execute(select(Setting).order_by(Setting.key))
+    return [SettingRead.model_validate(s) for s in result.scalars().all()]
+
+
+@router.put("/settings", response_model=list[SettingRead])
+async def update_settings(
+    data: SettingsUpdate,
+    session: AsyncSession = Depends(get_db),
+) -> list[SettingRead]:
+    for key, value in data.settings.items():
+        existing = await session.get(Setting, key)
+        if existing is None:
+            existing = Setting(key=key, value=value)
+            session.add(existing)
+        else:
+            existing.value = value
+    await session.commit()
+
+    result = await session.execute(select(Setting).order_by(Setting.key))
+    return [SettingRead.model_validate(s) for s in result.scalars().all()]

--- a/backend/app/api/v1/status.py
+++ b/backend/app/api/v1/status.py
@@ -1,0 +1,28 @@
+import shutil
+
+from fastapi import APIRouter
+
+from app.config import settings
+from app.core.queue import download_queue
+from app.models.schemas import StatusRead
+from app.services.alldebrid import AllDebridClient
+
+router = APIRouter()
+
+
+@router.get("/status", response_model=StatusRead)
+async def get_status() -> StatusRead:
+    try:
+        free_bytes = shutil.disk_usage(settings.download_path).free
+        disk_free_gb = round(free_bytes / 1_000_000_000, 2)
+    except OSError:
+        disk_free_gb = 0.0
+
+    alldebrid_ok = await AllDebridClient().ping()
+
+    return StatusRead(
+        queue_size=download_queue.size,
+        active=download_queue.active,
+        disk_free_gb=disk_free_gb,
+        alldebrid_ok=alldebrid_ok,
+    )

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -1,0 +1,47 @@
+import asyncio
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from app.core import events
+
+router = APIRouter()
+
+_PING_INTERVAL = 30.0  # seconds
+
+
+@router.websocket("/ws/downloads/{download_id}")
+async def ws_download_progress(websocket: WebSocket, download_id: str) -> None:
+    """Stream progress events for a specific download."""
+    await websocket.accept()
+    q = events.subscribe(download_id)
+    try:
+        while True:
+            try:
+                event = await asyncio.wait_for(q.get(), timeout=_PING_INTERVAL)
+                await websocket.send_json(event)
+                if event.get("status") in ("completed", "error"):
+                    break
+            except asyncio.TimeoutError:
+                await websocket.send_json({"type": "ping"})
+    except WebSocketDisconnect:
+        pass
+    finally:
+        events.unsubscribe(download_id, q)
+
+
+@router.websocket("/ws/queue")
+async def ws_queue(websocket: WebSocket) -> None:
+    """Stream progress events for all downloads (queue overview)."""
+    await websocket.accept()
+    q = events.subscribe(events.QUEUE_CHANNEL)
+    try:
+        while True:
+            try:
+                event = await asyncio.wait_for(q.get(), timeout=_PING_INTERVAL)
+                await websocket.send_json(event)
+            except asyncio.TimeoutError:
+                await websocket.send_json({"type": "ping"})
+    except WebSocketDisconnect:
+        pass
+    finally:
+        events.unsubscribe(events.QUEUE_CHANNEL, q)

--- a/backend/app/core/events.py
+++ b/backend/app/core/events.py
@@ -1,6 +1,8 @@
 import asyncio
 from collections import defaultdict
 
+QUEUE_CHANNEL = "__queue__"
+
 _subscribers: dict[str, list[asyncio.Queue]] = defaultdict(list)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,10 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.v1.router import router as api_v1_router
+from app.api.ws import router as ws_router
 from app.core.queue import download_queue
-from app.database import Base, AsyncSessionLocal, engine
+from app.database import AsyncSessionLocal, Base, engine
 from app.services.download_service import DownloadService
 
 
@@ -39,6 +41,9 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    app.include_router(api_v1_router)
+    app.include_router(ws_router)
 
     return app
 

--- a/backend/app/scrapers/wawacity.py
+++ b/backend/app/scrapers/wawacity.py
@@ -54,12 +54,27 @@ class WawacityScraper(BaseScraper):
         if year is not None:
             params["year"] = year
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(settings.wawacity_url, params=params) as resp:
-                if resp.status != 200:
-                    logger.error("Wawacity search returned HTTP %d", resp.status)
-                    return []
-                data = await resp.read()
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/124.0.0.0 Safari/537.36"
+            ),
+            "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        }
+        try:
+            async with aiohttp.ClientSession(headers=headers) as session:
+                async with session.get(
+                    settings.wawacity_url, params=params, allow_redirects=True
+                ) as resp:
+                    if resp.status != 200:
+                        logger.error("Wawacity search returned HTTP %d", resp.status)
+                        return []
+                    data = await resp.read()
+        except aiohttp.ClientError as exc:
+            logger.error("Wawacity search request failed: %s", exc)
+            return []
 
         return self._parse_results(data, limit)
 

--- a/backend/app/services/alldebrid.py
+++ b/backend/app/services/alldebrid.py
@@ -33,6 +33,21 @@ class AllDebridClient:
 
         return data["data"]["links"][0]
 
+    async def ping(self) -> bool:
+        """Return True if the AllDebrid API is reachable and the key is valid."""
+        params = {**self._base_params()}
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{_BASE_URL}/user", params=params
+                ) as response:
+                    if response.status != 200:
+                        return False
+                    data = await response.json()
+            return data.get("status") == "success"
+        except Exception:
+            return False
+
     async def debrid_link(self, url: str) -> dict:
         """Unlock a link via AllDebrid and return the unlock data."""
         if "dl-protect" in url:

--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -22,6 +22,12 @@ _DB_UPDATE_INTERVAL = 2.0  # seconds between DB writes during streaming
 _WS_EMIT_INTERVAL = 0.5  # seconds between WebSocket events during streaming
 
 
+async def _emit(download_id: str, event: dict) -> None:
+    """Emit to the per-download channel and to the global queue channel."""
+    await events.emit(download_id, event)
+    await events.emit(events.QUEUE_CHANNEL, event)
+
+
 class DownloadService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -74,7 +80,7 @@ class DownloadService:
 
         try:
             await self._set_status(download, "downloading")
-            await events.emit(
+            await _emit(
                 download_id,
                 WsProgressEvent(
                     download_id=download_id, status="downloading", progress_pct=0.0
@@ -98,7 +104,7 @@ class DownloadService:
                     filename=filename,
                     completed_at=datetime.now(UTC),
                 )
-                await events.emit(
+                await _emit(
                     download_id,
                     WsProgressEvent(
                         download_id=download_id,
@@ -115,7 +121,7 @@ class DownloadService:
 
         except Exception as exc:
             await self._set_status(download, "error", error=str(exc))
-            await events.emit(
+            await _emit(
                 download_id,
                 WsProgressEvent(
                     download_id=download_id,
@@ -163,7 +169,7 @@ class DownloadService:
                         )
 
                         if now - last_ws_emit >= _WS_EMIT_INTERVAL:
-                            await events.emit(
+                            await _emit(
                                 download_id,
                                 WsProgressEvent(
                                     download_id=download_id,
@@ -195,7 +201,7 @@ class DownloadService:
             filename=filename,
             completed_at=datetime.now(UTC),
         )
-        await events.emit(
+        await _emit(
             download_id,
             WsProgressEvent(
                 download_id=download_id,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,240 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.orm import Download, History, Setting
+from app.scrapers.base import SearchResult as ScraperSearchResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_download(db_session, **kwargs) -> Download:
+    defaults = dict(
+        title="Test Film",
+        source_url="https://1fichier.com/?abc",
+        media_type="movie",
+        destination="server",
+        status="queued",
+        progress_pct=0.0,
+    )
+    defaults.update(kwargs)
+    d = Download(**defaults)
+    db_session.add(d)
+    await db_session.commit()
+    await db_session.refresh(d)
+    return d
+
+
+async def _seed_history(db_session, **kwargs) -> History:
+    defaults = dict(
+        title="Old Movie",
+        source_url="https://1fichier.com/?xyz",
+        media_type="movie",
+        source="alldebrid",
+    )
+    defaults.update(kwargs)
+    h = History(**defaults)
+    db_session.add(h)
+    await db_session.commit()
+    await db_session.refresh(h)
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    async def test_returns_results(self, client) -> None:
+        fake_result = ScraperSearchResult(
+            title="Dune",
+            url="https://wawacity.city/dune",
+            source="wawacity",
+            year=2021,
+            quality="1080p",
+        )
+
+        with patch("app.api.v1.search.get_scraper") as mock_get:
+            mock_scraper = MagicMock()
+            mock_scraper.search = AsyncMock(return_value=[fake_result])
+            mock_get.return_value = mock_scraper
+
+            resp = await client.get("/api/v1/search?q=dune")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["results"][0]["title"] == "Dune"
+
+    async def test_unknown_source_returns_400(self, client) -> None:
+        resp = await client.get("/api/v1/search?q=dune&source=unknown")
+        assert resp.status_code == 400
+
+    async def test_empty_query_returns_422(self, client) -> None:
+        resp = await client.get("/api/v1/search?q=")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Downloads
+# ---------------------------------------------------------------------------
+
+
+class TestDownloads:
+    async def test_create_download_returns_201(self, client) -> None:
+        with patch("app.api.v1.downloads.download_queue") as mock_queue:
+            mock_queue.enqueue = AsyncMock()
+            resp = await client.post(
+                "/api/v1/downloads",
+                json={
+                    "source_url": "https://1fichier.com/?abc",
+                    "title": "My Film",
+                    "media_type": "movie",
+                },
+            )
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "download_id" in body
+        assert body["status"] == "queued"
+        mock_queue.enqueue.assert_awaited_once()
+
+    async def test_list_downloads_empty(self, client) -> None:
+        resp = await client.get("/api/v1/downloads")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_list_downloads_includes_active(self, client, db_session) -> None:
+        await _seed_download(db_session, status="downloading")
+        resp = await client.get("/api/v1/downloads")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    async def test_get_download_returns_404_for_unknown(self, client) -> None:
+        resp = await client.get("/api/v1/downloads/nonexistent")
+        assert resp.status_code == 404
+
+    async def test_get_download_returns_200(self, client, db_session) -> None:
+        d = await _seed_download(db_session)
+        resp = await client.get(f"/api/v1/downloads/{d.id}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == d.id
+
+    async def test_delete_download_returns_204(self, client, db_session) -> None:
+        d = await _seed_download(db_session)
+        resp = await client.delete(f"/api/v1/downloads/{d.id}")
+        assert resp.status_code == 204
+
+    async def test_delete_download_returns_404_for_unknown(self, client) -> None:
+        resp = await client.delete("/api/v1/downloads/nonexistent")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# History
+# ---------------------------------------------------------------------------
+
+
+class TestHistory:
+    async def test_list_history_empty(self, client) -> None:
+        resp = await client.get("/api/v1/history")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    async def test_list_history_returns_entries(self, client, db_session) -> None:
+        await _seed_history(db_session, title="Inception")
+        await _seed_history(db_session, title="Interstellar")
+        resp = await client.get("/api/v1/history")
+        assert resp.json()["total"] == 2
+
+    async def test_list_history_search_filter(self, client, db_session) -> None:
+        await _seed_history(db_session, title="Inception")
+        await _seed_history(db_session, title="Interstellar")
+        resp = await client.get("/api/v1/history?q=Inception")
+        assert resp.json()["total"] == 1
+        assert resp.json()["items"][0]["title"] == "Inception"
+
+    async def test_list_history_pagination(self, client, db_session) -> None:
+        for i in range(5):
+            await _seed_history(db_session, title=f"Film {i}")
+        resp = await client.get("/api/v1/history?page=2&limit=2")
+        body = resp.json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+        assert body["page"] == 2
+
+    async def test_delete_history_returns_204(self, client, db_session) -> None:
+        h = await _seed_history(db_session)
+        resp = await client.delete(f"/api/v1/history/{h.id}")
+        assert resp.status_code == 204
+
+    async def test_delete_history_returns_404_for_unknown(self, client) -> None:
+        resp = await client.delete("/api/v1/history/nonexistent")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+class TestSettings:
+    async def test_get_settings_empty(self, client) -> None:
+        resp = await client.get("/api/v1/settings")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    async def test_put_settings_creates_entries(self, client) -> None:
+        resp = await client.put(
+            "/api/v1/settings",
+            json={"settings": {"theme": "dark", "language": "fr"}},
+        )
+        assert resp.status_code == 200
+        keys = {s["key"] for s in resp.json()}
+        assert keys == {"theme", "language"}
+
+    async def test_put_settings_updates_existing(self, client) -> None:
+        await client.put("/api/v1/settings", json={"settings": {"theme": "dark"}})
+        resp = await client.put("/api/v1/settings", json={"settings": {"theme": "light"}})
+        assert resp.status_code == 200
+        settings = {s["key"]: s["value"] for s in resp.json()}
+        assert settings["theme"] == "light"
+
+    async def test_get_settings_returns_persisted(self, client) -> None:
+        await client.put("/api/v1/settings", json={"settings": {"foo": "bar"}})
+        resp = await client.get("/api/v1/settings")
+        settings = {s["key"]: s["value"] for s in resp.json()}
+        assert settings["foo"] == "bar"
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    async def test_get_status_returns_200(self, client) -> None:
+        with patch("app.api.v1.status.AllDebridClient") as MockClient:
+            MockClient.return_value.ping = AsyncMock(return_value=True)
+            resp = await client.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "queue_size" in body
+        assert "active" in body
+        assert "disk_free_gb" in body
+        assert body["alldebrid_ok"] is True
+
+    async def test_get_status_alldebrid_down(self, client) -> None:
+        with patch("app.api.v1.status.AllDebridClient") as MockClient:
+            MockClient.return_value.ping = AsyncMock(return_value=False)
+            resp = await client.get("/api/v1/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["alldebrid_ok"] is False

--- a/backend/tests/test_scrapers.py
+++ b/backend/tests/test_scrapers.py
@@ -152,7 +152,7 @@ async def test_search_returns_results(monkeypatch):
         async def __aexit__(self, *args):
             pass
 
-    monkeypatch.setattr(aiohttp, "ClientSession", lambda: FakeSession())
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda **kwargs: FakeSession())
 
     scraper = WawacityScraper()
     results = await scraper.search("inception", "films", limit=10)
@@ -187,7 +187,7 @@ async def test_search_returns_empty_on_http_error(monkeypatch):
         async def __aexit__(self, *args):
             pass
 
-    monkeypatch.setattr(aiohttp, "ClientSession", lambda: FakeSession())
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda **kwargs: FakeSession())
 
     scraper = WawacityScraper()
     results = await scraper.search("inception", "films")


### PR DESCRIPTION
## Summary

- **Search** — `GET /api/v1/search` : délègue au scraper (`source=wawacity|...`), convertit les dataclasses en schémas Pydantic
- **Downloads** — `POST /api/v1/downloads` (crée + enqueue), `GET` (liste active), `GET /{id}`, `DELETE /{id}`
- **History** — `GET /api/v1/history` (paginé, filtrable par titre), `DELETE /api/v1/history/{id}`
- **Settings** — `GET /api/v1/settings`, `PUT /api/v1/settings` (upsert key/value)
- **Status** — `GET /api/v1/status` : queue_size, active workers, disk free, AllDebrid ping
- **WebSocket** — `WS /ws/downloads/{id}` (progression d'un download), `WS /ws/queue` (broadcast toutes les mises à jour via `QUEUE_CHANNEL`)
- `AllDebridClient.ping()` pour le healthcheck
- `download_service` émet désormais sur le canal global `QUEUE_CHANNEL` en plus du canal par download

## Test plan

- [x] 22 tests API : search, downloads, history, settings, status
- [x] Suite complète : 89 tests, 0 régression

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)