### PR TITLE
feat(backend): migrate history.csv to SQLite on first startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,18 @@
+import csv
+import uuid
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import func, select
 
 from app.api.v1.router import router as api_v1_router
 from app.api.ws import router as ws_router
 from app.core.queue import download_queue
 from app.database import AsyncSessionLocal, Base, engine
+from app.models.orm import History
 from app.services.download_service import DownloadService
 
 
@@ -16,10 +22,48 @@ async def _run_download(download_id: str) -> None:
         await service.run(download_id)
 
 
+async def _migrate_csv_if_needed() -> None:
+    """Importe history.csv dans la table history si elle est vide."""
+    csv_path = Path(__file__).resolve().parents[3] / "history.csv"
+    if not csv_path.exists():
+        return
+
+    async with AsyncSessionLocal() as session:
+        count = await session.scalar(select(func.count()).select_from(History))
+        if count and count > 0:
+            return
+
+        with csv_path.open(newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        if not rows:
+            return
+
+        now = datetime.now(UTC)
+        entries = [
+            History(
+                id=str(uuid.uuid4()),
+                title=row["title"].strip(),
+                source_url=row["url"].strip(),
+                filename=row["title"].strip(),
+                media_type="unknown",
+                source="wawacity",
+                downloaded_at=now,
+            )
+            for row in rows
+            if row.get("title", "").strip() and row.get("url", "").strip()
+        ]
+
+        session.add_all(entries)
+        await session.commit()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    await _migrate_csv_if_needed()
     download_queue.set_handler(_run_download)
     download_queue.start()
     yield

--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ import asyncio
 from slugify import slugify
 from bs4 import BeautifulSoup
 import re
-import pandas as pd
+import csv
 
 from parser import Parser
 
@@ -371,7 +371,7 @@ async def download_url_selected(ctx, url_selected, folder, providers_list=None):
 
                     if filename:
                         histories.append({'title': filename, 'url': episode_name})
-                        pd.DataFrame(histories).to_csv('history.csv', index=False)
+                        _write_history_csv(histories)
                         await ctx.send(f'✅ {filename} — OK ({provider})')
                         downloaded = True
                         break  # ← épisode OK, on passe au suivant
@@ -409,7 +409,7 @@ async def download_url_selected(ctx, url_selected, folder, providers_list=None):
                         filename = await download_by_url(url, folder)
                         if filename:
                             histories.append({'title': filename, 'url': url})
-                            pd.DataFrame(histories).to_csv('history.csv', index=False)
+                            _write_history_csv(histories)
                             await ctx.send(f'✅ {filename} — OK ({provider})')
                             return  # ← film OK, on s'arrête
                         else:
@@ -582,6 +582,24 @@ async def search(ctx, query=None, category=None, year=None, count=3):
         await ctx.send('Error: No selection')
 
 
+_HISTORY_CSV = Path('history.csv')
+_HISTORY_FIELDNAMES = ['title', 'url']
+
+
+def _read_history_csv() -> list[dict]:
+    if not _HISTORY_CSV.exists():
+        return []
+    with _HISTORY_CSV.open(newline='', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
+def _write_history_csv(histories: list[dict]) -> None:
+    with _HISTORY_CSV.open('w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=_HISTORY_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(histories)
+
+
 if __name__ == '__main__':
     """
     Point d'entrée du bot Discord.
@@ -601,7 +619,6 @@ if __name__ == '__main__':
         - Gérer cas où le fichier est corrompu
         - Implémenter reconnexion automatique
     """
-    data = pd.read_csv('history.csv')
-    histories = data.to_dict(orient='records')
+    histories = _read_history_csv()
     
     bot.run(TOKEN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,5 @@ dependencies = [
     "requests>=2.31.0",
     "beautifulsoup4>=4.12.0",
     "seleniumbase>=4.26.0",
-    "pandas>=2.0.0",
     "python-slugify>=8.0.0",
 ]

--- a/scripts/migrate_csv.py
+++ b/scripts/migrate_csv.py
@@ -1,0 +1,86 @@
+"""
+Script one-shot : importe history.csv dans la table SQLite `history`.
+
+Usage :
+    python scripts/migrate_csv.py [--csv PATH] [--db PATH] [--force]
+
+Options :
+    --csv PATH   Chemin vers history.csv (défaut : history.csv à la racine)
+    --db  PATH   Chemin vers la base SQLite (défaut : backend/dl_bot.db)
+    --force      Re-importe même si la table n'est pas vide
+"""
+
+import argparse
+import csv
+import sqlite3
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def migrate(csv_path: Path, db_path: Path, force: bool = False) -> int:
+    if not csv_path.exists():
+        print(f"[SKIP] {csv_path} introuvable — rien à migrer.")
+        return 0
+
+    con = sqlite3.connect(db_path)
+    cur = con.cursor()
+
+    cur.execute("SELECT COUNT(*) FROM history")
+    count = cur.fetchone()[0]
+    if count > 0 and not force:
+        print(f"[SKIP] La table history contient déjà {count} ligne(s). Utilisez --force pour forcer.")
+        con.close()
+        return 0
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        print("[SKIP] history.csv est vide.")
+        con.close()
+        return 0
+
+    now = datetime.now(UTC).isoformat()
+    inserted = 0
+    for row in rows:
+        title = row.get("title", "").strip()
+        url = row.get("url", "").strip()
+        if not title or not url:
+            continue
+        cur.execute(
+            """
+            INSERT OR IGNORE INTO history
+                (id, title, source_url, filename, media_type, source, downloaded_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (str(uuid.uuid4()), title, url, title, "unknown", "wawacity", now),
+        )
+        inserted += 1
+
+    con.commit()
+    con.close()
+    print(f"[OK] {inserted} entrée(s) importée(s) depuis {csv_path} → {db_path}")
+    return inserted
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+
+    parser = argparse.ArgumentParser(description="Migre history.csv vers SQLite.")
+    parser.add_argument("--csv", type=Path, default=repo_root / "history.csv")
+    parser.add_argument("--db", type=Path, default=repo_root / "backend" / "dl_bot.db")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    if not args.db.exists():
+        print(f"[ERROR] Base de données introuvable : {args.db}", file=sys.stderr)
+        sys.exit(1)
+
+    migrate(args.csv, args.db, force=args.force)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #37

## Summary
- `scripts/migrate_csv.py` : script standalone one-shot pour importer `history.csv` dans la table `history` (options `--csv`, `--db`, `--force`)
- Auto-migration au premier démarrage du backend : si `history.csv` existe et que la table `history` est vide, l'import est déclenché automatiquement dans le lifespan FastAPI
- `bot.py` : remplacement de `pandas` par le module stdlib `csv` (`_read_history_csv` / `_write_history_csv`)
- Suppression de la dépendance `pandas` du `pyproject.toml` racine
- Bug `bot.py:459` (`and` → `or`) déjà corrigé sur la branche `v2`

## Test plan
- [ ] Lancer le backend avec un `history.csv` existant et une BDD vide → vérifier que les entrées apparaissent dans `/api/v1/history`
- [ ] Relancer le backend → vérifier que la migration n'est pas rejouée (table non vide)
- [ ] Lancer `python scripts/migrate_csv.py --help` → vérifier les options
- [ ] Lancer `python scripts/migrate_csv.py --force` → vérifier la re-importation
- [ ] Vérifier que `bot.py` lit/écrit correctement `history.csv` sans pandas

🤖 Generated with [Claude Code](https://claude.com/claude-code)