### PR TITLE
feat: Bruno collection — validation epic #28 backend

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_ENV_FILE = Path(__file__).resolve().parents[2] / ".env"
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=_ENV_FILE, env_file_encoding="utf-8")
 
     discord_token: str = ""
     discord_guild: str = ""

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "dl_discord_bot API",
+  "type": "collection"
+}

--- a/bruno/downloads/Create download.bru
+++ b/bruno/downloads/Create download.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Create download
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/downloads
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "source_url": "https://www.wawacity.city/films/inception-2010.html",
+    "title": "Inception 2010 FRENCH 1080p BluRay",
+    "media_type": "film",
+    "destination": "server"
+  }
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("downloadId", res.body.download_id);
+  }
+}
+
+tests {
+  test("status 201", function() {
+    expect(res.status).to.equal(201);
+  });
+
+  test("has download_id", function() {
+    expect(res.body).to.have.property("download_id");
+    expect(res.body.download_id).to.be.a("string");
+  });
+
+  test("status is queued", function() {
+    expect(res.body.status).to.equal("queued");
+  });
+}

--- a/bruno/downloads/Delete download.bru
+++ b/bruno/downloads/Delete download.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete download
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/downloads/{{downloadId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 204", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/bruno/downloads/Get download 404.bru
+++ b/bruno/downloads/Get download 404.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get download inexistant (404)
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/downloads/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/bruno/downloads/Get download by ID.bru
+++ b/bruno/downloads/Get download by ID.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get download by ID
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/downloads/{{downloadId}}
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has required fields", function() {
+    expect(res.body).to.have.property("id");
+    expect(res.body).to.have.property("title");
+    expect(res.body).to.have.property("status");
+    expect(res.body).to.have.property("progress_pct");
+  });
+}

--- a/bruno/downloads/List downloads.bru
+++ b/bruno/downloads/List downloads.bru
@@ -1,0 +1,21 @@
+meta {
+  name: List downloads
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/downloads
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("returns array", function() {
+    expect(res.body).to.be.an("array");
+  });
+}

--- a/bruno/environments/local.bru
+++ b/bruno/environments/local.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:8000
+  downloadId:
+}

--- a/bruno/environments/server.bru
+++ b/bruno/environments/server.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://192.168.1.23:8000
+  downloadId:
+}

--- a/bruno/history/Delete history entry.bru
+++ b/bruno/history/Delete history entry.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete history entry (404)
+  type: http
+  seq: 3
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/history/00000000-0000-0000-0000-000000000000
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 404", function() {
+    expect(res.status).to.equal(404);
+  });
+}

--- a/bruno/history/List history.bru
+++ b/bruno/history/List history.bru
@@ -5,14 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/v1/history
+  url: {{baseUrl}}/api/v1/history?page=1&limit=20
   body: none
   auth: none
-}
-
-params:query {
-  page: 1
-  limit: 20
 }
 
 tests {

--- a/bruno/history/List history.bru
+++ b/bruno/history/List history.bru
@@ -1,0 +1,35 @@
+meta {
+  name: List history
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/history
+  body: none
+  auth: none
+}
+
+params:query {
+  page: 1
+  limit: 20
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has pagination fields", function() {
+    expect(res.body).to.have.property("items");
+    expect(res.body).to.have.property("total");
+    expect(res.body).to.have.property("page");
+    expect(res.body).to.have.property("limit");
+    expect(res.body.items).to.be.an("array");
+  });
+
+  test("page is correct", function() {
+    expect(res.body.page).to.equal(1);
+    expect(res.body.limit).to.equal(20);
+  });
+}

--- a/bruno/history/Search history.bru
+++ b/bruno/history/Search history.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Search history (filtre titre)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/history
+  body: none
+  auth: none
+}
+
+params:query {
+  q: spider
+  page: 1
+  limit: 10
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("results match filter", function() {
+    res.body.items.forEach(function(item) {
+      expect(item.title.toLowerCase()).to.include("spider");
+    });
+  });
+}

--- a/bruno/history/Search history.bru
+++ b/bruno/history/Search history.bru
@@ -5,15 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/v1/history
+  url: {{baseUrl}}/api/v1/history?q=spider&page=1&limit=10
   body: none
   auth: none
-}
-
-params:query {
-  q: spider
-  page: 1
-  limit: 10
 }
 
 tests {

--- a/bruno/search/Search films.bru
+++ b/bruno/search/Search films.bru
@@ -5,16 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/v1/search
+  url: {{baseUrl}}/api/v1/search?q=inception&source=wawacity&category=films&limit=10
   body: none
   auth: none
-}
-
-params:query {
-  q: inception
-  source: wawacity
-  category: films
-  limit: 10
 }
 
 tests {

--- a/bruno/search/Search films.bru
+++ b/bruno/search/Search films.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Search films
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/search
+  body: none
+  auth: none
+}
+
+params:query {
+  q: inception
+  source: wawacity
+  category: films
+  limit: 10
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has results array", function() {
+    expect(res.body).to.have.property("results");
+    expect(res.body.results).to.be.an("array");
+  });
+
+  test("has total and source", function() {
+    expect(res.body).to.have.property("total");
+    expect(res.body).to.have.property("source");
+    expect(res.body.source).to.equal("wawacity");
+  });
+}

--- a/bruno/search/Search series.bru
+++ b/bruno/search/Search series.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Search series
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/search
+  body: none
+  auth: none
+}
+
+params:query {
+  q: breaking bad
+  source: wawacity
+  category: series
+  limit: 5
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has results array", function() {
+    expect(res.body.results).to.be.an("array");
+  });
+}

--- a/bruno/search/Search series.bru
+++ b/bruno/search/Search series.bru
@@ -5,16 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/v1/search
+  url: {{baseUrl}}/api/v1/search?q=breaking+bad&source=wawacity&category=series&limit=5
   body: none
   auth: none
-}
-
-params:query {
-  q: breaking bad
-  source: wawacity
-  category: series
-  limit: 5
 }
 
 tests {

--- a/bruno/search/Search source inconnue.bru
+++ b/bruno/search/Search source inconnue.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Search source inconnue (400)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/search
+  body: none
+  auth: none
+}
+
+params:query {
+  q: inception
+  source: unknown_source
+  category: films
+}
+
+tests {
+  test("status 400", function() {
+    expect(res.status).to.equal(400);
+  });
+}

--- a/bruno/search/Search source inconnue.bru
+++ b/bruno/search/Search source inconnue.bru
@@ -5,15 +5,9 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/api/v1/search
+  url: {{baseUrl}}/api/v1/search?q=inception&source=unknown_source&category=films
   body: none
   auth: none
-}
-
-params:query {
-  q: inception
-  source: unknown_source
-  category: films
 }
 
 tests {

--- a/bruno/settings/Get settings.bru
+++ b/bruno/settings/Get settings.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get settings
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/settings
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("returns array", function() {
+    expect(res.body).to.be.an("array");
+  });
+}

--- a/bruno/settings/Update settings.bru
+++ b/bruno/settings/Update settings.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Update settings
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/v1/settings
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "settings": {
+      "max_concurrent_downloads": "2",
+      "download_path": "/data/media"
+    }
+  }
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("returns updated settings", function() {
+    expect(res.body).to.be.an("array");
+    const keys = res.body.map(function(s) { return s.key; });
+    expect(keys).to.include("max_concurrent_downloads");
+    expect(keys).to.include("download_path");
+  });
+}

--- a/bruno/status/Get status.bru
+++ b/bruno/status/Get status.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get status
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/status
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("has required fields", function() {
+    expect(res.body).to.have.property("queue_size");
+    expect(res.body).to.have.property("active");
+    expect(res.body).to.have.property("disk_free_gb");
+    expect(res.body).to.have.property("alldebrid_ok");
+  });
+}


### PR DESCRIPTION
Closes #28 (validation)

## Summary
- Collection Bruno dans `bruno/` couvrant tous les endpoints REST de l'epic #28
- Environnement `local` avec `baseUrl = http://localhost:8000`
- Assertions sur status code + shape de la réponse pour chaque requête

## Requêtes incluses

| Dossier | Requête |
|---|---|
| `status` | GET /api/v1/status |
| `search` | Search films, Search series, Source inconnue (400) |
| `downloads` | Create (201 + save `downloadId`), List, Get by ID, Get 404, Delete |
| `history` | List (paginé), Search par titre, Delete 404 |
| `settings` | Get, Update |

## Utilisation
```bash
# Ouvrir dans Bruno → collection bruno/
# Sélectionner l'environnement "local"
# Démarrer le backend : cd backend && uv run uvicorn app.main:app --reload
```

## Test plan
- [ ] Ouvrir la collection dans Bruno et sélectionner l'environnement `local`
- [ ] Démarrer le backend
- [ ] Lancer toutes les requêtes → tous les tests passent au vert
- [ ] Vérifier que "Create download" stocke bien le `downloadId` pour les requêtes chaînées

🤖 Generated with [Claude Code](https://claude.com/claude-code)