### PR TITLE
test(bruno): alldebrid_ok assert + requête test 1fichier

### DIFF
--- a/bruno/downloads/Test debrid 1fichier.bru
+++ b/bruno/downloads/Test debrid 1fichier.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Test debrid 1fichier
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/v1/downloads
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "source_url": "https://1fichier.com/?XXXXXXXXXXXXXXXX",
+    "title": "Test 1fichier",
+    "media_type": "film",
+    "destination": "server"
+  }
+}
+
+script:post-response {
+  if (res.status === 201) {
+    bru.setVar("downloadId", res.body.download_id);
+  }
+}
+
+tests {
+  test("status 201", function() {
+    expect(res.status).to.equal(201);
+  });
+
+  test("download enqueued", function() {
+    expect(res.body.download_id).to.be.a("string");
+    expect(res.body.status).to.equal("queued");
+  });
+}

--- a/bruno/status/Get status.bru
+++ b/bruno/status/Get status.bru
@@ -21,4 +21,8 @@ tests {
     expect(res.body).to.have.property("disk_free_gb");
     expect(res.body).to.have.property("alldebrid_ok");
   });
+
+  test("alldebrid reachable", function() {
+    expect(res.body.alldebrid_ok).to.equal(true);
+  });
 }


### PR DESCRIPTION
## Summary
- Status : ajout assert `alldebrid_ok: true` pour valider la clé API AllDebrid
- Nouveau fichier `downloads/Test debrid 1fichier.bru` : test end-to-end debrid avec un lien 1fichier.com direct

## Test plan
- [ ] `GET /api/v1/status` → `alldebrid_ok: true`
- [ ] Remplacer `XXXXXXXXXXXXXXXX` par un vrai hash 1fichier et lancer la requête → `201 Created` + téléchargement visible dans les logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)