### PR TITLE
feat(bot): thin client HTTP vers le backend FastAPI (#38)

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+_RETRY_STATUSES = {500, 502, 503, 504}
+
+
+class BackendError(Exception):
+    def __init__(self, status: int, message: str) -> None:
+        self.status = status
+        super().__init__(message)
+
+
+class BackendClient:
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        retries: int = 2,
+        **kwargs: Any,
+    ) -> Any:
+        url = f"{self._base_url}{path}"
+        session = await self._get_session()
+
+        last_exc: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                async with session.request(method, url, **kwargs) as resp:
+                    if resp.status in _RETRY_STATUSES and attempt < retries:
+                        logger.warning("Backend %s %s → %s, retry %d", method, path, resp.status, attempt + 1)
+                        continue
+                    if resp.status >= 400:
+                        body = await resp.text()
+                        raise BackendError(resp.status, f"HTTP {resp.status}: {body[:200]}")
+                    if resp.status == 204:
+                        return None
+                    return await resp.json()
+            except aiohttp.ClientError as exc:
+                last_exc = exc
+                if attempt < retries:
+                    logger.warning("Backend connection error, retry %d: %s", attempt + 1, exc)
+                    continue
+                raise BackendError(0, f"Connection error: {exc}") from exc
+
+        raise BackendError(0, f"All retries exhausted: {last_exc}")
+
+    # --- Search ---
+
+    async def search(
+        self,
+        q: str,
+        source: str = "wawacity",
+        category: str | None = None,
+        year: int | None = None,
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"q": q, "source": source, "limit": limit}
+        if category:
+            params["category"] = category
+        if year:
+            params["year"] = year
+        return await self._request("GET", "/api/v1/search", params=params)
+
+    # --- Downloads ---
+
+    async def create_download(
+        self,
+        source_url: str,
+        title: str,
+        media_type: str,
+        destination: str = "server",
+    ) -> dict[str, Any]:
+        payload = {
+            "source_url": source_url,
+            "title": title,
+            "media_type": media_type,
+            "destination": destination,
+        }
+        return await self._request("POST", "/api/v1/downloads", json=payload)
+
+    async def get_downloads(self) -> list[dict[str, Any]]:
+        return await self._request("GET", "/api/v1/downloads")
+
+    # --- Status ---
+
+    async def get_status(self) -> dict[str, Any]:
+        return await self._request("GET", "/api/v1/status")

--- a/bot/cogs/download.py
+++ b/bot/cogs/download.py
@@ -1,0 +1,93 @@
+import logging
+
+import discord
+from discord.ext import commands
+
+from client import BackendClient, BackendError
+
+logger = logging.getLogger(__name__)
+
+_VALID_MEDIA_TYPES = ["movie", "serie", "manga"]
+_STATUS_COLORS = {
+    "pending": discord.Color.light_grey(),
+    "downloading": discord.Color.blue(),
+    "done": discord.Color.green(),
+    "error": discord.Color.red(),
+    "cancelled": discord.Color.orange(),
+}
+
+
+class DownloadCog(commands.Cog):
+    def __init__(self, bot: commands.Bot, backend: BackendClient) -> None:
+        self.bot = bot
+        self.backend = backend
+
+    @commands.command(name="url", help="Télécharge une URL: !url <url> <media_type>  (movie|serie|manga)")
+    async def url(
+        self,
+        ctx: commands.Context,
+        url: str | None = None,
+        media_type: str | None = None,
+    ) -> None:
+        if url is None:
+            await ctx.send("URL invalide.")
+            return
+
+        if media_type is None or media_type not in _VALID_MEDIA_TYPES:
+            embed = discord.Embed(
+                title="Type de média invalide",
+                description="Types disponibles: `movie`, `serie`, `manga`\nEx: `!url https://... movie`",
+                color=discord.Color.red(),
+            )
+            await ctx.send(embed=embed)
+            return
+
+        logger.info("%s enqueue download: %s (%s)", ctx.author, url[:80], media_type)
+
+        try:
+            result = await self.backend.create_download(
+                source_url=url,
+                title=url,
+                media_type=media_type,
+                destination="server",
+            )
+        except BackendError as exc:
+            logger.error("url backend error: %s", exc)
+            await ctx.send(f"Erreur backend ({exc.status}): impossible d'enqueue le téléchargement.")
+            return
+
+        embed = discord.Embed(
+            title="Téléchargement enqueued",
+            color=discord.Color.green(),
+        )
+        embed.add_field(name="ID", value=f"`{result['download_id']}`", inline=False)
+        embed.add_field(name="Statut", value=result["status"], inline=True)
+        await ctx.send(embed=embed)
+
+    @commands.command(name="status", help="Affiche la file de téléchargement et le statut du serveur")
+    async def status(self, ctx: commands.Context) -> None:
+        try:
+            status_data = await self.backend.get_status()
+            downloads = await self.backend.get_downloads()
+        except BackendError as exc:
+            logger.error("status backend error: %s", exc)
+            await ctx.send(f"Erreur backend ({exc.status}): impossible de récupérer le statut.")
+            return
+
+        alldebrid_icon = "✅" if status_data.get("alldebrid_ok") else "❌"
+
+        embed = discord.Embed(title="Statut du serveur", color=discord.Color.blurple())
+        embed.add_field(name="AllDebrid", value=alldebrid_icon, inline=True)
+        embed.add_field(name="File", value=str(status_data.get("queue_size", 0)), inline=True)
+        embed.add_field(name="Actifs", value=str(status_data.get("active", 0)), inline=True)
+        embed.add_field(name="Disque libre", value=f"{status_data.get('disk_free_gb', 0):.1f} Go", inline=True)
+
+        if downloads:
+            lines = []
+            for dl in downloads[:10]:
+                pct = dl.get("progress_pct", 0)
+                bar = "█" * int(pct / 10) + "░" * (10 - int(pct / 10))
+                lines.append(f"`{bar}` {pct:.0f}% — {dl.get('title', dl['id'])[:40]} [{dl['status']}]")
+            embed.add_field(name="Téléchargements actifs", value="\n".join(lines), inline=False)
+
+        await ctx.send(embed=embed)

--- a/bot/cogs/search.py
+++ b/bot/cogs/search.py
@@ -1,0 +1,108 @@
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from client import BackendClient, BackendError
+
+logger = logging.getLogger(__name__)
+
+_NUMBERS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"]
+_VALID_CATEGORIES = ["films", "series", "mangas"]
+_CATEGORY_TO_MEDIA_TYPE = {"films": "movie", "series": "serie", "mangas": "manga"}
+
+
+def _build_embed(result: dict, index: int, total: int) -> discord.Embed:
+    embed = discord.Embed(color=0x0099FF, title=result["title"])
+    if result.get("poster_url"):
+        embed.set_image(url=result["poster_url"])
+    embed.add_field(name="Année", value=result.get("year") or "—", inline=True)
+    embed.add_field(name="Qualité", value=result.get("quality") or "—", inline=True)
+    embed.add_field(name="Langue", value=result.get("language") or "—", inline=True)
+    embed.set_footer(text=f"Page {index + 1}/{total}")
+    return embed
+
+
+class SearchCog(commands.Cog):
+    def __init__(self, bot: commands.Bot, backend: BackendClient) -> None:
+        self.bot = bot
+        self.backend = backend
+
+    @commands.command(name="search", help="Recherche: !search <query> <category> [year] [count=3]")
+    async def search(
+        self,
+        ctx: commands.Context,
+        query: str | None = None,
+        category: str | None = None,
+        year: int | None = None,
+        count: int = 3,
+    ) -> None:
+        if query is None:
+            await ctx.send("Erreur: requête vide")
+            return
+
+        if category is None or category not in _VALID_CATEGORIES:
+            embed = discord.Embed(
+                title="Catégorie invalide",
+                description="Catégories disponibles: `films`, `series`, `mangas`\nEx: `!search Dragon Ball series`",
+                color=discord.Color.red(),
+            )
+            await ctx.send(embed=embed)
+            return
+
+        count = min(count, 10)
+
+        try:
+            response = await self.backend.search(query, category=category, year=year, limit=count)
+        except BackendError as exc:
+            logger.error("search backend error: %s", exc)
+            await ctx.send(f"Erreur backend ({exc.status}): impossible d'effectuer la recherche.")
+            return
+
+        results = response.get("results", [])
+        if not results:
+            await ctx.send("Aucun résultat trouvé.")
+            return
+
+        # Send one embed per result; only the last one gets reactions
+        last_msg: discord.Message | None = None
+        for i, result in enumerate(results):
+            last_msg = await ctx.send(embed=_build_embed(result, i, len(results)))
+
+        if last_msg is None:
+            return
+
+        for i in range(len(results)):
+            await last_msg.add_reaction(_NUMBERS[i])
+
+        def check(r: discord.Reaction, u: discord.User) -> bool:
+            return u == ctx.message.author and str(r.emoji) in _NUMBERS
+
+        selected = None
+        try:
+            reaction, _ = await self.bot.wait_for("reaction_add", timeout=30.0, check=check)
+            await last_msg.remove_reaction(reaction.emoji, ctx.message.author)
+            selected = results[_NUMBERS.index(str(reaction.emoji))]
+        except asyncio.TimeoutError:
+            await ctx.send("Temps écoulé — aucune sélection.")
+        finally:
+            await last_msg.delete()
+
+        if selected is None:
+            return
+
+        await ctx.send(f"Sélectionné : **{selected['title']}**")
+
+        media_type = _CATEGORY_TO_MEDIA_TYPE[category]
+        try:
+            result = await self.backend.create_download(
+                source_url=selected["url"],
+                title=selected["title"],
+                media_type=media_type,
+                destination="server",
+            )
+            await ctx.send(f"✅ Téléchargement enqueued — ID `{result['download_id']}` (statut: {result['status']})")
+        except BackendError as exc:
+            logger.error("create_download backend error: %s", exc)
+            await ctx.send(f"Erreur lors de la mise en file ({exc.status}).")

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,57 @@
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+
+from client import BackendClient
+from cogs.download import DownloadCog
+from cogs.search import SearchCog
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+TOKEN = os.getenv("DISCORD_TOKEN", "")
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler(Path(__file__).parent / "bot.log"),
+    ],
+)
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    if not TOKEN:
+        logger.error("DISCORD_TOKEN non défini dans .env")
+        sys.exit(1)
+
+    intents = discord.Intents.default()
+    intents.message_content = True
+
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    backend = BackendClient(BACKEND_URL)
+
+    await bot.add_cog(SearchCog(bot, backend))
+    await bot.add_cog(DownloadCog(bot, backend))
+
+    @bot.event
+    async def on_ready() -> None:
+        logger.info("Bot connecté en tant que %s", bot.user)
+
+    try:
+        await bot.start(TOKEN)
+    finally:
+        await backend.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "dl-discord-bot"
+version = "2.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "discord.py>=2.4",
+    "aiohttp>=3.11",
+    "python-dotenv>=1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -7,7 +7,3 @@ dependencies = [
     "aiohttp>=3.11",
     "python-dotenv>=1.0",
 ]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

- **`bot/client.py`** — `BackendClient` aiohttp avec retry sur 5xx et `BackendError` pour les 4xx
- **`bot/cogs/search.py`** — `!search <query> <category> [year] [count]` : appelle `/api/v1/search`, affiche des embeds avec pagination emoji, enqueue via `/api/v1/downloads`
- **`bot/cogs/download.py`** — `!url <url> <media_type>` et `!status` : embed de la file active + statut AllDebrid/disque
- **`bot/main.py`** — entry point async propre, charge les cogs, ferme la session à l'arrêt
- **`bot/pyproject.toml`** — dépendances allégées : `discord.py`, `aiohttp`, `python-dotenv` (sans selenium/pandas/bs4)

## Test plan

- [ ] `!search "Dragon Ball" series` retourne des résultats via le backend
- [ ] Sélection par emoji enqueue le téléchargement et confirme l'ID
- [ ] Timeout 30s affiche "Temps écoulé" sans crash
- [ ] `!url https://wawacity.city/... movie` enqueue et retourne l'embed avec l'ID
- [ ] `!url <url> invalidtype` affiche l'embed d'erreur
- [ ] `!status` affiche la file, le statut AllDebrid et l'espace disque
- [ ] Si backend down → message d'erreur Discord (pas de crash)

Closes #38 — Partie de l'epic #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)