### PR TITLE
feat: téléchargement de séries par épisode (#69)

### DIFF
--- a/backend/app/api/v1/episodes.py
+++ b/backend/app/api/v1/episodes.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.schemas import EpisodeLinkRead, EpisodeRead
+from app.scrapers.base import get_scraper
+
+router = APIRouter()
+
+
+@router.get("/episodes", response_model=list[EpisodeRead])
+async def get_episodes(
+    url: str = Query(..., description="URL de la page série"),
+    source: str = Query("wawacity", description="Scraper source"),
+    providers: str = Query("", description="Providers filtrés, séparés par virgule"),
+) -> list[EpisodeRead]:
+    try:
+        scraper = get_scraper(source)
+    except KeyError:
+        raise HTTPException(status_code=400, detail=f"Unknown source: {source!r}")
+
+    provider_list = [p.strip() for p in providers.split(",") if p.strip()]
+
+    try:
+        raw = await scraper.get_episodes(url, provider_list or None)
+    except NotImplementedError:
+        raise HTTPException(status_code=501, detail=f"Episodes not implemented for source: {source!r}")
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Scraper error: {exc}") from exc
+
+    return [
+        EpisodeRead(
+            title=ep.title,
+            number=ep.number,
+            links=[
+                EpisodeLinkRead(provider=pl.provider, url=pl.urls[0])
+                for pl in ep.provider_links
+                if pl.urls
+            ],
+        )
+        for ep in raw
+    ]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
-from app.api.v1 import downloads, history, search, settings, status
+from app.api.v1 import downloads, episodes, history, search, settings, status
 
 router = APIRouter(prefix="/api/v1")
 
 router.include_router(search.router)
+router.include_router(episodes.router)
 router.include_router(downloads.router)
 router.include_router(history.router)
 router.include_router(settings.router)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -24,6 +24,20 @@ class SearchResponse(BaseModel):
     source: str
 
 
+# --- Episodes ---
+
+
+class EpisodeLinkRead(BaseModel):
+    provider: str
+    url: str
+
+
+class EpisodeRead(BaseModel):
+    title: str
+    number: int
+    links: list[EpisodeLinkRead]
+
+
 # --- Downloads ---
 
 
@@ -116,3 +130,4 @@ class WsProgressEvent(BaseModel):
     speed_mbps: float | None = None
     eta_s: int | None = None
     filename: str | None = None
+    debrid_url: str | None = None

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -24,6 +24,13 @@ class ProviderLinks:
     urls: list[str] = field(default_factory=list)
 
 
+@dataclass
+class Episode:
+    title: str
+    number: int
+    provider_links: list[ProviderLinks] = field(default_factory=list)
+
+
 def register(cls: type["BaseScraper"]) -> type["BaseScraper"]:
     _registry[cls.source_name] = cls
     logger.debug("Registered scraper: %s", cls.source_name)
@@ -55,6 +62,13 @@ class BaseScraper(ABC):
         url: str,
         providers: list[str],
     ) -> list[ProviderLinks]: ...
+
+    @abstractmethod
+    async def get_episodes(
+        self,
+        url: str,
+        providers: list[str] | None = None,
+    ) -> list[Episode]: ...
 
     async def resolve_link(self, url: str) -> str:
         """Resolve any link protection layer and return the real provider URL.

--- a/backend/app/scrapers/darkiworld.py
+++ b/backend/app/scrapers/darkiworld.py
@@ -1,4 +1,4 @@
-from app.scrapers.base import BaseScraper, ProviderLinks, SearchResult, register
+from app.scrapers.base import BaseScraper, Episode, ProviderLinks, SearchResult, register
 
 
 @register
@@ -20,4 +20,11 @@ class DarkiworldScraper(BaseScraper):
         url: str,
         providers: list[str],
     ) -> list[ProviderLinks]:
+        raise NotImplementedError("darkiworld: not implemented yet")
+
+    async def get_episodes(
+        self,
+        url: str,
+        providers: list[str] | None = None,
+    ) -> list[Episode]:
         raise NotImplementedError("darkiworld: not implemented yet")

--- a/backend/app/scrapers/wawacity.py
+++ b/backend/app/scrapers/wawacity.py
@@ -10,7 +10,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from seleniumbase import Driver, SB
 
 from app.config import settings
-from app.scrapers.base import BaseScraper, ProviderLinks, SearchResult, register
+from app.scrapers.base import BaseScraper, Episode, ProviderLinks, SearchResult, register
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +158,94 @@ class WawacityScraper(BaseScraper):
         return await loop.run_in_executor(
             None, self._fetch_provider_links, url, providers
         )
+
+    async def get_episodes(
+        self,
+        url: str,
+        providers: list[str] | None = None,
+    ) -> list[Episode]:
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/124.0.0.0 Safari/537.36"
+            ),
+            "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+        }
+        try:
+            async with aiohttp.ClientSession(headers=headers) as session:
+                async with session.get(url, allow_redirects=True) as resp:
+                    if resp.status != 200:
+                        logger.error("Wawacity episodes returned HTTP %d", resp.status)
+                        return []
+                    data = await resp.read()
+        except aiohttp.ClientError as exc:
+            logger.error("Wawacity episodes request failed: %s", exc)
+            return []
+
+        return self._parse_episodes(data.decode("utf-8", errors="replace"), providers or [])
+
+    def _parse_episodes(self, html: str, providers: list[str]) -> list[Episode]:
+        soup = BeautifulSoup(html, "html.parser")
+        table = soup.find("table", id="DDLLinks")
+        if table is None:
+            logger.warning("DDLLinks table not found on episode page")
+            return []
+
+        episodes: list[Episode] = []
+        current_title: str | None = None
+        current_number: int = 0
+        current_links: dict[str, list[str]] = {}
+
+        for tr in table.find_all("tr"):
+            classes = tr.get("class", [])
+
+            if "episode-title" in classes:
+                # Save the previous episode group
+                if current_title is not None:
+                    episodes.append(Episode(
+                        title=current_title,
+                        number=current_number,
+                        provider_links=[
+                            ProviderLinks(provider=p, urls=urls)
+                            for p, urls in current_links.items()
+                        ],
+                    ))
+                # Parse the new episode title
+                td = tr.find("td")
+                text = td.get_text(strip=True) if td else ""
+                text = re.sub(
+                    r"\s*en\s+t[eé]l[eé]chargement.*$", "", text, flags=re.IGNORECASE
+                ).strip()
+                m = re.search(r"[ÉéEe]pisode\s+(\d+)", text)
+                current_number = int(m.group(1)) if m else len(episodes) + 1
+                current_title = f"Épisode {current_number}"
+                current_links = {}
+
+            elif "link-row" in classes and current_title is not None:
+                tds = tr.find_all("td")
+                if len(tds) < 2:
+                    continue
+                a = tds[0].find("a", href=True)
+                provider_name = tds[1].get_text(strip=True)
+                if not a or not provider_name:
+                    continue
+                if providers and provider_name not in providers:
+                    continue
+                current_links.setdefault(provider_name, []).append(a["href"])
+
+        # Save the last episode group
+        if current_title is not None:
+            episodes.append(Episode(
+                title=current_title,
+                number=current_number,
+                provider_links=[
+                    ProviderLinks(provider=p, urls=urls)
+                    for p, urls in current_links.items()
+                ],
+            ))
+
+        return episodes
 
     async def resolve_link(self, url: str) -> str:
         """Resolve dl-protect intermediary pages to the actual provider URL."""

--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -81,12 +81,13 @@ class DownloadService:
     # Download execution
     # ------------------------------------------------------------------
 
-    def _scraper_for_url(self, url: str) -> BaseScraper:
+    def _scraper_for_url(self, url: str) -> BaseScraper | None:
+        """Return the scraper for the given URL, or None if it's a direct provider link."""
         netloc = urlparse(url).netloc
         for keyword, source_name in _SCRAPER_DOMAINS.items():
             if keyword in netloc:
                 return get_scraper(source_name)
-        raise DownloadError(f"No scraper available for host: {netloc}")
+        return None
 
     async def run(self, download_id: str) -> None:
         """Scrape provider links, debrid, then download. Called by the queue worker."""
@@ -95,36 +96,43 @@ class DownloadService:
             raise DownloadNotFoundError(download_id)
 
         try:
-            # Step 1 — scrape provider links from the source page
-            await self._set_status(download, "scraping")
-            await _emit(
-                download_id,
-                WsProgressEvent(
-                    download_id=download_id, status="scraping", progress_pct=0.0
-                ).model_dump(),
-            )
-
             scraper = self._scraper_for_url(download.source_url)
-            provider_links = await scraper.get_provider_links(download.source_url, [])
 
-            if not provider_links:
-                raise DownloadError("No provider links found on the page")
+            if scraper is not None:
+                # Step 1 — scrape provider links from the source page
+                await self._set_status(download, "scraping")
+                await _emit(
+                    download_id,
+                    WsProgressEvent(
+                        download_id=download_id, status="scraping", progress_pct=0.0
+                    ).model_dump(),
+                )
 
-            _PREFERRED_PROVIDERS = ["Turbobit", "Rapidgator", "1fichier"]
-            chosen = next(
-                (pl for name in _PREFERRED_PROVIDERS for pl in provider_links if pl.provider == name and pl.urls),
-                next((pl for pl in provider_links if pl.urls), None),
-            )
-            if chosen is None:
-                raise DownloadError("No usable provider link found on the page")
+                provider_links = await scraper.get_provider_links(download.source_url, [])
 
-            dl_protect_url = chosen.urls[0]
-            logger.info(
-                "Download %s — provider: %s dl-protect: %s",
-                download_id,
-                chosen.provider,
-                dl_protect_url,
-            )
+                if not provider_links:
+                    raise DownloadError("No provider links found on the page")
+
+                _PREFERRED_PROVIDERS = ["Turbobit", "Rapidgator", "1fichier"]
+                chosen = next(
+                    (pl for name in _PREFERRED_PROVIDERS for pl in provider_links if pl.provider == name and pl.urls),
+                    next((pl for pl in provider_links if pl.urls), None),
+                )
+                if chosen is None:
+                    raise DownloadError("No usable provider link found on the page")
+
+                dl_protect_url = chosen.urls[0]
+                logger.info(
+                    "Download %s — provider: %s dl-protect: %s",
+                    download_id,
+                    chosen.provider,
+                    dl_protect_url,
+                )
+            else:
+                # source_url is already a direct provider/dl-protect link (e.g. episode download)
+                dl_protect_url = download.source_url
+                scraper = get_scraper("wawacity")
+                logger.info("Download %s — direct provider URL: %s", download_id, dl_protect_url)
 
             # Step 2 — resolve dl-protect intermediary to real provider URL
             await self._set_status(download, "resolving")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models.orm import Download, History, Setting
-from app.scrapers.base import SearchResult as ScraperSearchResult
+from app.scrapers.base import Episode, ProviderLinks, SearchResult as ScraperSearchResult
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +77,65 @@ class TestSearch:
     async def test_empty_query_returns_422(self, client) -> None:
         resp = await client.get("/api/v1/search?q=")
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Episodes
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodes:
+    async def test_returns_episodes(self, client) -> None:
+        fake_ep = Episode(
+            title="Épisode 1",
+            number=1,
+            provider_links=[ProviderLinks(provider="Rapidgator", urls=["https://dl-protect.link/ep1"])],
+        )
+
+        with patch("app.api.v1.episodes.get_scraper") as mock_get:
+            mock_scraper = MagicMock()
+            mock_scraper.get_episodes = AsyncMock(return_value=[fake_ep])
+            mock_get.return_value = mock_scraper
+
+            resp = await client.get("/api/v1/episodes?url=https://wawacity.pizza?p=serie%26id=1")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["number"] == 1
+        assert body[0]["title"] == "Épisode 1"
+        assert body[0]["links"][0]["provider"] == "Rapidgator"
+        assert body[0]["links"][0]["url"] == "https://dl-protect.link/ep1"
+
+    async def test_unknown_source_returns_400(self, client) -> None:
+        resp = await client.get("/api/v1/episodes?url=https://example.com&source=unknown")
+        assert resp.status_code == 400
+
+    async def test_not_implemented_returns_501(self, client) -> None:
+        with patch("app.api.v1.episodes.get_scraper") as mock_get:
+            mock_scraper = MagicMock()
+            mock_scraper.get_episodes = AsyncMock(side_effect=NotImplementedError)
+            mock_get.return_value = mock_scraper
+
+            resp = await client.get("/api/v1/episodes?url=https://darkiworld.com/serie&source=darkiworld")
+
+        assert resp.status_code == 501
+
+    async def test_missing_url_returns_422(self, client) -> None:
+        resp = await client.get("/api/v1/episodes")
+        assert resp.status_code == 422
+
+    async def test_provider_filter_forwarded(self, client) -> None:
+        with patch("app.api.v1.episodes.get_scraper") as mock_get:
+            mock_scraper = MagicMock()
+            mock_scraper.get_episodes = AsyncMock(return_value=[])
+            mock_get.return_value = mock_scraper
+
+            await client.get("/api/v1/episodes?url=https://wawacity.pizza?p=serie%26id=1&providers=Rapidgator")
+
+        mock_scraper.get_episodes.assert_awaited_once_with(
+            "https://wawacity.pizza?p=serie&id=1", ["Rapidgator"]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_download_service.py
+++ b/backend/tests/test_download_service.py
@@ -7,6 +7,7 @@ from app.core import events
 from app.core.exceptions import DownloadError, DownloadNotFoundError
 from app.models.orm import Download
 from app.models.schemas import DownloadCreate
+from app.scrapers.wawacity import WawacityScraper
 from app.services.download_service import DownloadService
 
 
@@ -101,6 +102,18 @@ class TestListActive:
         assert any(x.id == d.id for x in active)
 
 
+class TestScraperForUrl:
+    def test_returns_wawacity_scraper_for_wawacity_url(self, service: DownloadService) -> None:
+        scraper = service._scraper_for_url("https://www.wawacity.pizza?p=film&id=1")
+        assert isinstance(scraper, WawacityScraper)
+
+    def test_returns_none_for_dl_protect_url(self, service: DownloadService) -> None:
+        assert service._scraper_for_url("https://dl-protect.link/abc123") is None
+
+    def test_returns_none_for_unknown_host(self, service: DownloadService) -> None:
+        assert service._scraper_for_url("https://1fichier.com/?abc") is None
+
+
 def _mock_scraper(provider_url: str = "https://turbobit.net/abc123"):
     """Return a mock scraper that yields one Turbobit provider link."""
     from app.scrapers.base import ProviderLinks
@@ -168,6 +181,60 @@ class TestRunClientDestination:
         ):
             await service.run(download.id)
             mock_open.assert_not_called()
+
+
+class TestRunDirectUrl:
+    """When source_url is a direct dl-protect link (episode), scraping is skipped."""
+
+    async def test_direct_url_skips_scraping_and_completes(
+        self, service: DownloadService
+    ) -> None:
+        data = DownloadCreate(
+            source_url="https://dl-protect.link/ep1abc",
+            title="Breaking Bad S01E01",
+            media_type="serie",
+            destination="client",
+        )
+        download = await service.create(data)
+
+        debrid_data = {"link": "https://cdn.example.com/bb.mkv", "filename": "bb.mkv"}
+        mock_scraper = MagicMock()
+        mock_scraper.resolve_link = AsyncMock(return_value="https://rapidgator.net/file/abc")
+
+        with (
+            patch("app.services.download_service.get_scraper", return_value=mock_scraper),
+            patch.object(service._alldebrid, "debrid_link", new=AsyncMock(return_value=debrid_data)),
+            patch("app.services.download_service.events.emit", new=AsyncMock()),
+        ):
+            await service.run(download.id)
+
+        refreshed = await service.get(download.id)
+        assert refreshed is not None
+        assert refreshed.status == "completed"
+        mock_scraper.resolve_link.assert_awaited_once_with("https://dl-protect.link/ep1abc")
+
+    async def test_direct_url_never_calls_get_provider_links(
+        self, service: DownloadService
+    ) -> None:
+        data = DownloadCreate(
+            source_url="https://dl-protect.link/ep1abc",
+            title="Episode Test",
+            media_type="serie",
+            destination="client",
+        )
+        download = await service.create(data)
+
+        mock_scraper = MagicMock()
+        mock_scraper.resolve_link = AsyncMock(return_value="https://rapidgator.net/file/abc")
+
+        with (
+            patch("app.services.download_service.get_scraper", return_value=mock_scraper),
+            patch.object(service._alldebrid, "debrid_link", new=AsyncMock(return_value={"link": "https://cdn.example.com/ep.mkv", "filename": "ep.mkv"})),
+            patch("app.services.download_service.events.emit", new=AsyncMock()),
+        ):
+            await service.run(download.id)
+
+        mock_scraper.get_provider_links.assert_not_called()
 
 
 class TestRunErrors:

--- a/backend/tests/test_scrapers.py
+++ b/backend/tests/test_scrapers.py
@@ -1,7 +1,7 @@
 import pytest
 
 import app.scrapers  # noqa: F401 — triggers @register decorators
-from app.scrapers.base import ProviderLinks, SearchResult, get_scraper
+from app.scrapers.base import Episode, ProviderLinks, SearchResult, get_scraper
 from app.scrapers.darkiworld import DarkiworldScraper
 from app.scrapers.wawacity import WawacityScraper
 
@@ -212,3 +212,169 @@ async def test_darkiworld_get_provider_links_raises_not_implemented():
     scraper = DarkiworldScraper()
     with pytest.raises(NotImplementedError):
         await scraper.get_provider_links("https://example.com", [])
+
+
+@pytest.mark.asyncio
+async def test_darkiworld_get_episodes_raises_not_implemented():
+    scraper = DarkiworldScraper()
+    with pytest.raises(NotImplementedError):
+        await scraper.get_episodes("https://example.com")
+
+
+# ---------------------------------------------------------------------------
+# WawacityScraper._parse_episodes
+# ---------------------------------------------------------------------------
+
+_DDLLINKS_HTML = """
+<html><body>
+<table id="DDLLinks">
+  <tr class="link-row">
+    <td><a href="https://dl-protect.link/season-pack">Lien premium</a></td>
+    <td class="text-center">Anonyme</td><td class="text-center">1 Go</td><td></td>
+  </tr>
+  <tr class="title episode-title active">
+    <td colspan="6"><p>Breaking Bad - Saison 1<i> - VOSTFR HD</i> - Épisode 1en téléchargement sur wawa city</p></td>
+  </tr>
+  <tr class="link-row">
+    <td><a href="https://dl-protect.link/ep1-rapid">Lien 1:Télécharger</a></td>
+    <td class="text-center">Rapidgator</td><td class="text-center">250 Mo</td><td></td>
+  </tr>
+  <tr class="link-row">
+    <td><a href="https://dl-protect.link/ep1-nitro">Lien 2:Télécharger</a></td>
+    <td class="text-center">Nitroflare</td><td class="text-center">250 Mo</td><td></td>
+  </tr>
+  <tr class="title episode-title active">
+    <td colspan="6"><p>Breaking Bad - Saison 1<i> - VOSTFR HD</i> - Épisode 2en téléchargement sur wawa city</p></td>
+  </tr>
+  <tr class="link-row">
+    <td><a href="https://dl-protect.link/ep2-rapid">Lien 1:Télécharger</a></td>
+    <td class="text-center">Rapidgator</td><td class="text-center">250 Mo</td><td></td>
+  </tr>
+</table>
+</body></html>
+"""
+
+
+def test_parse_episodes_returns_two_episodes():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, [])
+    assert len(episodes) == 2
+
+
+def test_parse_episodes_correct_numbers():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, [])
+    assert episodes[0].number == 1
+    assert episodes[1].number == 2
+
+
+def test_parse_episodes_correct_titles():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, [])
+    assert episodes[0].title == "Épisode 1"
+    assert episodes[1].title == "Épisode 2"
+
+
+def test_parse_episodes_provider_links():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, [])
+    providers = [pl.provider for pl in episodes[0].provider_links]
+    assert "Rapidgator" in providers
+    assert "Nitroflare" in providers
+
+
+def test_parse_episodes_dl_protect_urls():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, [])
+    rapid = next(pl for pl in episodes[0].provider_links if pl.provider == "Rapidgator")
+    assert rapid.urls[0] == "https://dl-protect.link/ep1-rapid"
+
+
+def test_parse_episodes_filters_providers():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, ["Rapidgator"])
+    for ep in episodes:
+        assert all(pl.provider == "Rapidgator" for pl in ep.provider_links)
+
+
+def test_parse_episodes_skips_pre_episode_link_row():
+    """The first link-row (before any episode-title) is the season pack — must be skipped."""
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes(_DDLLINKS_HTML, [])
+    all_urls = [pl.urls[0] for ep in episodes for pl in ep.provider_links]
+    assert "https://dl-protect.link/season-pack" not in all_urls
+
+
+def test_parse_episodes_empty_html():
+    scraper = WawacityScraper()
+    episodes = scraper._parse_episodes("<html><body></body></html>", [])
+    assert episodes == []
+
+
+@pytest.mark.asyncio
+async def test_get_episodes_returns_episodes(monkeypatch):
+    import aiohttp
+
+    class FakeResponse:
+        status = 200
+
+        async def read(self):
+            return _DDLLINKS_HTML.encode()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def get(self, *args, **kwargs):
+            return FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda **kwargs: FakeSession())
+
+    scraper = WawacityScraper()
+    episodes = await scraper.get_episodes("https://www.wawacity.pizza?p=serie&id=1")
+
+    assert len(episodes) == 2
+    assert all(isinstance(ep, Episode) for ep in episodes)
+
+
+@pytest.mark.asyncio
+async def test_get_episodes_returns_empty_on_http_error(monkeypatch):
+    import aiohttp
+
+    class FakeResponse:
+        status = 503
+
+        async def read(self):
+            return b""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def get(self, *args, **kwargs):
+            return FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda **kwargs: FakeSession())
+
+    scraper = WawacityScraper()
+    episodes = await scraper.get_episodes("https://www.wawacity.pizza?p=serie&id=1")
+
+    assert episodes == []

--- a/bruno/episodes/Get episodes darkiworld (501).bru
+++ b/bruno/episodes/Get episodes darkiworld (501).bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get episodes Darkiworld (501)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/v1/episodes?url=https://darkiworld.com/serie&source=darkiworld
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 501", function() {
+    expect(res.status).to.equal(501);
+  });
+}

--- a/bruno/episodes/Get episodes serie.bru
+++ b/bruno/episodes/Get episodes serie.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Get episodes série
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/episodes?url=https://www.wawacity.pizza?p=serie%26id=2000-breaking-bad-saison1&source=wawacity
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("returns an array", function() {
+    expect(res.body).to.be.an("array");
+    expect(res.body.length).to.be.greaterThan(0);
+  });
+
+  test("each episode has number, title and links", function() {
+    const ep = res.body[0];
+    expect(ep).to.have.property("number");
+    expect(ep).to.have.property("title");
+    expect(ep).to.have.property("links");
+    expect(ep.links).to.be.an("array");
+  });
+
+  test("each link has provider and url", function() {
+    const link = res.body[0].links[0];
+    expect(link).to.have.property("provider");
+    expect(link).to.have.property("url");
+    expect(link.url).to.include("dl-protect");
+  });
+}

--- a/bruno/episodes/Get episodes source inconnue (400).bru
+++ b/bruno/episodes/Get episodes source inconnue (400).bru
@@ -1,0 +1,17 @@
+meta {
+  name: Get episodes source inconnue (400)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/episodes?url=https://example.com&source=unknown_source
+  body: none
+  auth: none
+}
+
+tests {
+  test("status 400", function() {
+    expect(res.status).to.equal(400);
+  });
+}

--- a/frontend/src/app/core/models/download.type.ts
+++ b/frontend/src/app/core/models/download.type.ts
@@ -12,6 +12,7 @@ export type Download = {
   created_at: string;
   completed_at: string | null;
   error: string | null;
+  debrid_url: string | null;
 };
 
 export type DownloadCreated = {

--- a/frontend/src/app/core/models/episode.type.ts
+++ b/frontend/src/app/core/models/episode.type.ts
@@ -1,0 +1,10 @@
+export type EpisodeLink = {
+  provider: string;
+  url: string;
+};
+
+export type Episode = {
+  title: string;
+  number: number;
+  links: EpisodeLink[];
+};

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -6,6 +6,7 @@ import type { Download, DownloadCreated, StartDownloadPayload } from '../models/
 import type { HistoryList } from '../models/history.type';
 import type { SettingRead } from '../models/setting.type';
 import type { ApiStatus } from '../models/api-status.type';
+import type { Episode } from '../models/episode.type';
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
@@ -67,5 +68,11 @@ export class ApiService {
 
   getStatus(): Observable<ApiStatus> {
     return this.http.get<ApiStatus>(`${this.base}/status`);
+  }
+
+  getEpisodes(url: string, source = 'wawacity', providers?: string[]): Observable<Episode[]> {
+    let params = new HttpParams().set('url', url).set('source', source);
+    if (providers?.length) params = params.set('providers', providers.join(','));
+    return this.http.get<Episode[]>(`${this.base}/episodes`, { params });
   }
 }

--- a/frontend/src/app/core/services/ws.service.ts
+++ b/frontend/src/app/core/services/ws.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { defer, retry } from 'rxjs';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 
 export interface QueueEvent {
@@ -20,15 +21,14 @@ export class WsService {
   private queueSocket?: WebSocketSubject<QueueEvent>;
 
   watchQueue(): Observable<QueueEvent> {
-    if (!this.queueSocket || this.queueSocket.closed) {
+    return defer(() => {
       this.queueSocket = webSocket<QueueEvent>(`${this.wsBase}/queue`);
-    }
-    return this.queueSocket.asObservable();
+      return this.queueSocket;
+    }).pipe(retry({ delay: 3000 }));
   }
 
   watchDownload(id: string): Observable<QueueEvent> {
-    const socket = webSocket<QueueEvent>(`${this.wsBase}/downloads/${id}`);
-    return socket.asObservable();
+    return webSocket<QueueEvent>(`${this.wsBase}/downloads/${id}`);
   }
 
   closeQueue(): void {

--- a/frontend/src/app/features/downloads/downloads.component.html
+++ b/frontend/src/app/features/downloads/downloads.component.html
@@ -140,8 +140,16 @@
                 }
               </div>
               @if (d.status === 'completed') {
-                <div class="w-24 h-0.5 rounded-full" style="background:var(--mid)"></div>
-                <span class="text-[9px] font-black ml-2" style="color:var(--lime)">100%</span>
+                @if (d.debrid_url) {
+                  <a [href]="d.debrid_url" target="_blank" rel="noopener"
+                     class="text-[9px] font-black px-2 py-1 rounded transition"
+                     style="background:rgba(167,209,41,.12);color:var(--lime);border:1px solid rgba(167,209,41,.2)">
+                    ↓ RÉCUPÉRER
+                  </a>
+                } @else {
+                  <div class="w-24 h-0.5 rounded-full" style="background:var(--mid)"></div>
+                  <span class="text-[9px] font-black ml-2" style="color:var(--lime)">100%</span>
+                }
               }
               <button (click)="remove(d.id)"
                       class="w-7 h-7 rounded flex items-center justify-center transition text-xs shrink-0 ml-1"

--- a/frontend/src/app/features/downloads/downloads.component.ts
+++ b/frontend/src/app/features/downloads/downloads.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, linkedSignal, effect, inject, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
+import { Component, computed, linkedSignal, effect, inject, ChangeDetectionStrategy, DestroyRef, DOCUMENT } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DecimalPipe } from '@angular/common';
 import { ApiService } from '#core/services/api.service';
@@ -16,6 +16,7 @@ export class DownloadsComponent {
   private readonly api = inject(ApiService);
   private readonly ws = inject(WsService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly document = inject(DOCUMENT);
 
   private readonly resource = rxResource({
     stream: () => this.api.getDownloads(),
@@ -50,10 +51,14 @@ export class DownloadsComponent {
                   progress_pct: event.progress_pct ?? d.progress_pct,
                   speed_mbps: event.speed_mbps ?? d.speed_mbps,
                   eta_s: event.eta_s ?? d.eta_s,
+                  debrid_url: event.debrid_url ?? d.debrid_url,
                 }
               : d
           )
         );
+        if (event.debrid_url) {
+          this.triggerBrowserDownload(event.debrid_url, event.filename ?? undefined);
+        }
         if (['completed', 'error', 'cancelled', 'queued'].includes(event.status)) {
           this.resource.reload();
         }
@@ -88,8 +93,20 @@ export class DownloadsComponent {
           )
         );
       },
+      error: () => this.subscribedIds.delete(id),
       complete: () => this.subscribedIds.delete(id),
     });
+  }
+
+  triggerBrowserDownload(url: string, filename?: string): void {
+    const a = this.document.createElement('a');
+    a.href = url;
+    if (filename) a.download = filename;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    this.document.body.appendChild(a);
+    a.click();
+    this.document.body.removeChild(a);
   }
 
   formatEta(seconds: number): string {

--- a/frontend/src/app/features/search/search.component.html
+++ b/frontend/src/app/features/search/search.component.html
@@ -106,7 +106,7 @@
     @for (r of results(); track r.url) {
       <div class="result-card rounded overflow-hidden cursor-pointer"
            style="background:#0c0c0c;border:1px solid #1a1f10"
-           (click)="openModal(r)">
+           (click)="openResult(r)">
         <div class="relative">
           @if (r.poster_url) {
             <img [src]="r.poster_url" [alt]="r.title"
@@ -117,7 +117,9 @@
           }
           <div class="card-cta absolute inset-0 flex items-end p-2"
                style="background:linear-gradient(to top,rgba(0,0,0,.95) 0%,rgba(0,0,0,.5) 60%,transparent 100%)">
-            <span class="text-[10px] font-black" style="color:var(--lime)">[ DOWNLOAD ]</span>
+            <span class="text-[10px] font-black" style="color:var(--lime)">
+            {{ category() === 'series' ? '[ ÉPISODES ]' : '[ DOWNLOAD ]' }}
+          </span>
           </div>
           @if (r.quality) {
             <span class="absolute top-1.5 right-1.5 text-[9px] font-black px-1.5 py-0.5 rounded"
@@ -225,9 +227,126 @@
   </div>
 }
 
+<!-- Episodes panel -->
+@if (episodePanelOpen() && selectedResult()) {
+  <div class="fixed inset-0 z-50 flex items-center justify-center p-4"
+       style="background:rgba(0,0,0,.85)"
+       (click)="closeEpisodePanel()">
+    <div class="w-full max-w-md rounded-lg overflow-hidden flex flex-col"
+         style="background:#080808;border:1px solid #1a1f10;max-height:85vh"
+         (click)="$event.stopPropagation()">
+
+      <div style="height:2px;background:linear-gradient(90deg,var(--dark),var(--mid),var(--lime))"></div>
+
+      <!-- Header -->
+      <div class="px-5 pt-4 pb-3 flex items-start gap-3 shrink-0"
+           style="border-bottom:1px solid #1a1f10">
+        @if (selectedResult()!.poster_url) {
+          <img [src]="selectedResult()!.poster_url" [alt]="selectedResult()!.title"
+               class="w-12 rounded shrink-0" style="border:1px solid #2d3520" />
+        }
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-black leading-tight truncate" style="color:#e8ecd8">
+            {{ selectedResult()!.title }}
+          </p>
+          <p class="text-[9px] tracking-widest mt-1" style="color:#4a5a2a">// SÉLECTIONNER LES ÉPISODES</p>
+        </div>
+        <button (click)="closeEpisodePanel()" style="color:#3a4022;font-size:1.25rem;line-height:1"
+                onmouseover="this.style.color='#8a9a55'"
+                onmouseout="this.style.color='#3a4022'">&times;</button>
+      </div>
+
+      <!-- Destination -->
+      <div class="px-5 py-3 shrink-0" style="border-bottom:1px solid #1a1f10">
+        <div class="flex gap-1.5">
+          <button class="flex-1 py-1.5 rounded text-[11px] font-black flex items-center justify-center gap-1 transition"
+                  [style.background]="selectedDestination() === 'server' ? 'var(--dark)' : 'transparent'"
+                  [style.color]="selectedDestination() === 'server' ? 'var(--lime)' : '#6b7a4a'"
+                  [style.border]="selectedDestination() === 'server' ? '1px solid var(--mid)' : '1px solid #1a1f10'"
+                  (click)="selectedDestination.set('server')">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"/>
+            </svg>
+            Server
+          </button>
+          <button class="flex-1 py-1.5 rounded text-[11px] font-black flex items-center justify-center gap-1 transition"
+                  [style.background]="selectedDestination() === 'client' ? 'var(--dark)' : 'transparent'"
+                  [style.color]="selectedDestination() === 'client' ? 'var(--lime)' : '#6b7a4a'"
+                  [style.border]="selectedDestination() === 'client' ? '1px solid var(--mid)' : '1px solid #1a1f10'"
+                  (click)="selectedDestination.set('client')">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.1-1.1m.758-4.9a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+            </svg>
+            Direct
+          </button>
+        </div>
+      </div>
+
+      <!-- Episode list -->
+      <div class="overflow-y-auto flex-1">
+        @if (episodesLoading()) {
+          <div class="px-5 py-8 text-center">
+            <p class="text-[10px] tracking-widest" style="color:#3a4022">CHARGEMENT DES ÉPISODES…</p>
+          </div>
+        } @else if (episodes().length === 0) {
+          <div class="px-5 py-8 text-center">
+            <p class="text-[10px] tracking-widest" style="color:#3a4022">AUCUN ÉPISODE TROUVÉ</p>
+          </div>
+        } @else {
+          <div class="divide-y" style="border-color:#1a1f10">
+            @for (ep of episodes(); track ep.number) {
+              <div class="ep-row px-5 py-3 flex items-center gap-3">
+                <span class="text-[9px] font-mono w-6 shrink-0 text-right" style="color:#2d3520">
+                  {{ ep.number.toString().padStart(2, '0') }}
+                </span>
+                <div class="flex-1 min-w-0">
+                  <p class="text-xs font-bold" style="color:#c8d890">{{ ep.title }}</p>
+                  <div class="flex gap-1 mt-0.5 flex-wrap">
+                    @for (link of ep.links; track link.provider) {
+                      <span class="text-[8px] px-1 py-0.5 rounded font-mono"
+                            style="background:rgba(62,67,46,.3);color:#6b7a4a;border:1px solid #1a1f10">
+                        {{ link.provider }}
+                      </span>
+                    }
+                  </div>
+                </div>
+                <button (click)="downloadEpisode(ep)" [disabled]="launching()"
+                        class="shrink-0 w-7 h-7 rounded flex items-center justify-center transition"
+                        style="background:rgba(167,209,41,.1);border:1px solid rgba(167,209,41,.2);color:var(--lime)"
+                        onmouseover="this.style.background='rgba(167,209,41,.2)'"
+                        onmouseout="this.style.background='rgba(167,209,41,.1)'">
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
+                  </svg>
+                </button>
+              </div>
+            }
+          </div>
+        }
+      </div>
+
+      <!-- Footer -->
+      @if (episodes().length > 0) {
+        <div class="px-5 py-3 shrink-0" style="border-top:1px solid #1a1f10">
+          <button (click)="downloadAll()" [disabled]="launchingAll() || launching()"
+                  class="w-full py-2 rounded text-xs font-black transition"
+                  style="background:var(--lime);color:#000">
+            {{ launchingAll() ? '…' : 'TOUT TÉLÉCHARGER (' + episodes().length + ' épisodes) →' }}
+          </button>
+        </div>
+      }
+    </div>
+  </div>
+}
+
 <style>
   .result-card { transition: transform .18s, border-color .18s; }
   .result-card:hover { transform: translateY(-4px); border-color: var(--lime) !important; }
   .result-card:hover .card-cta { opacity: 1; }
   .card-cta { opacity: 0; transition: opacity .18s; }
+  .ep-row { transition: background .15s; }
+  .ep-row:hover { background: rgba(167,209,41,.03); }
 </style>

--- a/frontend/src/app/features/search/search.component.ts
+++ b/frontend/src/app/features/search/search.component.ts
@@ -2,10 +2,12 @@ import { Component, signal, computed, linkedSignal, inject, ChangeDetectionStrat
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { EMPTY, forkJoin } from 'rxjs';
 import { ApiService } from '#core/services/api.service';
 import { CATEGORIES } from '#core/constants/media';
 import type { SearchResult } from '#core/models/search.type';
 import type { StartDownloadPayload } from '#core/models/download.type';
+import type { Episode, EpisodeLink } from '#core/models/episode.type';
 
 type SearchParams = {
   q: string;
@@ -13,6 +15,8 @@ type SearchParams = {
   year?: string;
   sort?: string;
 };
+
+const PREFERRED_PROVIDERS = ['Turbobit', 'Rapidgator', '1fichier'];
 
 @Component({
   selector: 'app-search',
@@ -78,12 +82,24 @@ export class SearchComponent {
 
   protected readonly skeletons = Array.from({ length: 6 });
 
-  // Modal state
+  // --- Film/manga modal ---
   protected modalOpen = signal(false);
   protected selectedResult = signal<SearchResult | null>(null);
   protected selectedDestination = signal<'server' | 'client'>('server');
   protected launching = signal(false);
   protected launchError = signal('');
+
+  // --- Episodes panel ---
+  protected episodePanelOpen = signal(false);
+  protected launchingAll = signal(false);
+
+  protected readonly episodesResource = rxResource({
+    params: () => this.episodePanelOpen() ? this.selectedResult() : null,
+    stream: ({ params }) => params ? this.api.getEpisodes(params.url) : EMPTY,
+  });
+
+  protected episodes = computed(() => this.episodesResource.value() ?? []);
+  protected episodesLoading = computed(() => this.episodesResource.isLoading());
 
   search(): void {
     const q = this.query().trim();
@@ -96,15 +112,23 @@ export class SearchComponent {
     });
   }
 
-  openModal(result: SearchResult): void {
+  openResult(result: SearchResult): void {
     this.selectedResult.set(result);
     this.selectedDestination.set('server');
     this.launchError.set('');
-    this.modalOpen.set(true);
+    if (this.category() === 'series') {
+      this.episodePanelOpen.set(true);
+    } else {
+      this.modalOpen.set(true);
+    }
   }
 
   closeModal(): void {
     this.modalOpen.set(false);
+  }
+
+  closeEpisodePanel(): void {
+    this.episodePanelOpen.set(false);
   }
 
   startDownload(): void {
@@ -130,10 +154,72 @@ export class SearchComponent {
     });
   }
 
+  downloadEpisode(ep: Episode): void {
+    const url = this.pickBestLink(ep.links);
+    if (!url) return;
+    const r = this.selectedResult()!;
+    const payload: StartDownloadPayload = {
+      source_url: url,
+      title: `${r.title} — ${ep.title}`,
+      media_type: 'series',
+      destination: this.selectedDestination(),
+    };
+    this.launching.set(true);
+    this.api.startDownload(payload).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.launching.set(false);
+        this.closeEpisodePanel();
+        this.router.navigate(['/downloads']);
+      },
+      error: () => {
+        this.launching.set(false);
+      },
+    });
+  }
+
+  downloadAll(): void {
+    const r = this.selectedResult();
+    const eps = this.episodes();
+    if (!r || !eps.length) return;
+
+    const requests = eps
+      .map(ep => ({ ep, url: this.pickBestLink(ep.links) }))
+      .filter(({ url }) => !!url)
+      .map(({ ep, url }) =>
+        this.api.startDownload({
+          source_url: url!,
+          title: `${r.title} — ${ep.title}`,
+          media_type: 'series',
+          destination: this.selectedDestination(),
+        })
+      );
+
+    if (!requests.length) return;
+    this.launchingAll.set(true);
+    forkJoin(requests).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.launchingAll.set(false);
+        this.closeEpisodePanel();
+        this.router.navigate(['/downloads']);
+      },
+      error: () => {
+        this.launchingAll.set(false);
+      },
+    });
+  }
+
   qualityColor(quality: string | null): string {
     if (!quality) return '#8a9a55';
     if (quality === '4K' || quality === '2160p') return '#e8d62a';
     if (quality === '1080p') return 'var(--lime)';
     return '#8a9a55';
+  }
+
+  private pickBestLink(links: EpisodeLink[]): string | null {
+    for (const provider of PREFERRED_PROVIDERS) {
+      const link = links.find(l => l.provider === provider);
+      if (link) return link.url;
+    }
+    return links[0]?.url ?? null;
   }
 }


### PR DESCRIPTION
Closes #69

## Summary

- **Backend** : endpoint `GET /api/v1/episodes` — parse les épisodes depuis le `#DDLLinks` Wawacity, retourne titres + liens dl-protect par provider
- **Backend** : `DownloadService` accepte un dl-protect URL direct en `source_url` (skip scraping) — permet le download d'épisodes individuels
- **Frontend** : clic sur une série → panel épisodes avec liste, download unitaire et "Tout télécharger"
- **Fix** : `WsProgressEvent` incluait pas `debrid_url` → download client ne déclenchait jamais le téléchargement navigateur
- **Fix** : `WsService.watchQueue()` se reconnecte automatiquement après redémarrage backend (defer + retry 3s)
- **Fix** : CloseEvent 1006 ne remonte plus comme erreur Angular non gérée

## Test plan

- [x] Recherche catégorie **SERIES** → clic sur un résultat → panel épisodes s'ouvre avec la liste
- [x] Clic **↓** sur un épisode → téléchargement lancé → redirect `/downloads`
- [x] Clic **TOUT TÉLÉCHARGER** → tous les épisodes mis en queue
- [x] Download avec destination **Direct** → le navigateur propose le fichier automatiquement
- [x] Redémarrage backend → WS se reconnecte sans refresh page
- [x] `GET /api/v1/episodes?url=...` → 200 avec liste d'épisodes (Bruno collection)
- [x] 109 tests backend passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)