### PR TITLE
fix(#65): retry provider fallback + error surfacé dans WS event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ Docs complètes : `docs/plan-v2.md` et `docs/architecture-v2.md`
 ### Développement (local)
 
 ```bash
-# Backend
+# Backend (sert aussi le frontend buildé sur :8000)
 cd backend
 uv run uvicorn app.main:app --reload --port 8000
 
-# Frontend
+# Frontend hot-reload (dev uniquement)
 cd frontend
 ng serve --port 4200
 
@@ -33,12 +33,18 @@ uv run python main.py
 ### Production (systemd)
 
 ```bash
-# Première installation
+# Première installation (build Angular + migrations + services)
 bash deploy/install.sh
 
-# Redémarrer après une mise à jour
+# Redémarrer après une mise à jour du backend
 sudo systemctl restart dl_backend.service discord_bot.service
+
+# Redémarrer après une mise à jour du frontend
+cd frontend && ng build --configuration production
+sudo systemctl restart dl_backend.service
 ```
+
+> L'interface web est accessible sur **`http://<serveur>:8000`** — servie directement par FastAPI.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,18 @@ cp .env.example .env
 ### 2. Développement local
 
 ```bash
-# Backend
+# Backend (sert aussi le frontend buildé sur :8000)
 cd backend && uv run uvicorn app.main:app --reload --port 8000
 
-# Frontend
+# Frontend (hot-reload dev uniquement)
 cd frontend && ng serve --port 4200
 
 # Bot Discord
 cd bot && uv run python main.py
 ```
+
+> En dev, utilise `ng serve :4200` pour le hot-reload.  
+> Le build Angular (`ng build`) est servi directement par FastAPI sur `:8000`.
 
 ### 3. Production (systemd)
 
@@ -45,7 +48,9 @@ cd bot && uv run python main.py
 bash deploy/install.sh
 ```
 
-> Installe et démarre `dl_backend.service` + `discord_bot.service`.  
+> Build le frontend Angular, applique les migrations, puis installe et démarre  
+> `dl_backend.service` + `discord_bot.service`.  
+> L'interface web est accessible sur **`http://<serveur>:8000`**.  
 > Voir `deploy/` pour les fichiers unit.
 
 ---

--- a/backend/app/api/v1/downloads.py
+++ b/backend/app/api/v1/downloads.py
@@ -49,3 +49,16 @@ async def delete_download(
     deleted = await service.delete(download_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Download not found")
+
+
+@router.post("/downloads/{download_id}/retry", response_model=DownloadCreated)
+async def retry_download(
+    download_id: str,
+    session: AsyncSession = Depends(get_db),
+) -> DownloadCreated:
+    service = DownloadService(session)
+    download = await service.retry(download_id)
+    if download is None:
+        raise HTTPException(status_code=404, detail="Download not found or not in error state")
+    await download_queue.enqueue(download.id)
+    return DownloadCreated(download_id=download.id, status=download.status)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
 from sqlalchemy import func, select
 
 from app.api.v1.router import router as api_v1_router
@@ -107,7 +109,37 @@ def create_app() -> FastAPI:
     app.include_router(api_v1_router)
     app.include_router(ws_router)
 
+    _mount_frontend(app)
+
     return app
+
+
+def _mount_frontend(app: FastAPI) -> None:
+    """Monte le build Angular en fichiers statiques si disponible.
+
+    Doit être appelé en dernier dans create_app() pour que les routes API
+    soient prioritaires sur le catch-all SPA.
+    """
+    frontend_dist = (
+        Path(__file__).resolve().parents[2] / "frontend" / "dist" / "frontend" / "browser"
+    ).resolve()
+
+    if not frontend_dist.exists():
+        return
+
+    index_html = frontend_dist / "index.html"
+
+    # Catch-all SPA : sert les fichiers statiques Angular si présents,
+    # sinon index.html pour que le router Angular gère la route.
+    # Les routes /api/ et /ws/ ne sont pas interceptées (404 natif FastAPI).
+    @app.get("/{full_path:path}", include_in_schema=False)
+    async def spa_fallback(full_path: str) -> FileResponse:
+        if full_path.startswith(("api/", "ws/")):
+            raise HTTPException(status_code=404)
+        candidate = frontend_dist / full_path
+        if full_path and candidate.exists() and candidate.is_file():
+            return FileResponse(candidate)
+        return FileResponse(index_html)
 
 
 app = create_app()

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -131,3 +131,4 @@ class WsProgressEvent(BaseModel):
     eta_s: int | None = None
     filename: str | None = None
     debrid_url: str | None = None
+    error: str | None = None

--- a/backend/app/scrapers/wawacity.py
+++ b/backend/app/scrapers/wawacity.py
@@ -14,6 +14,10 @@ from app.scrapers.base import BaseScraper, Episode, ProviderLinks, SearchResult,
 
 logger = logging.getLogger(__name__)
 
+# Selenium ne supporte pas plusieurs sessions Chrome simultanées —
+# on sérialise les appels _dl_protect_sync avec un semaphore à 1 slot.
+_dl_protect_sem = asyncio.Semaphore(1)
+
 _XPATH_LINK = '//*[@id="protected-container"]/div[2]/div/ul/li/a'
 
 _LANGUAGE_MAP: dict[str, str] = {
@@ -296,7 +300,8 @@ class WawacityScraper(BaseScraper):
 
     async def _resolve_dl_protect(self, url: str) -> str:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self._dl_protect_sync, url)
+        async with _dl_protect_sem:
+            return await loop.run_in_executor(None, self._dl_protect_sync, url)
 
     def _dl_protect_sync(self, url: str) -> str:
         with SB(uc=True, test=False) as sb:

--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -77,6 +77,20 @@ class DownloadService:
         await self._session.commit()
         return True
 
+    async def retry(self, download_id: str) -> Download | None:
+        """Reset a failed download and re-enqueue it."""
+        download = await self.get(download_id)
+        if download is None or download.status != "error":
+            return None
+        download.status = "queued"
+        download.error = None
+        download.progress_pct = 0.0
+        download.speed_mbps = None
+        download.completed_at = None
+        await self._session.commit()
+        await self._session.refresh(download)
+        return download
+
     # ------------------------------------------------------------------
     # Download execution
     # ------------------------------------------------------------------

--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.core import events
-from app.core.exceptions import DownloadError, DownloadNotFoundError
+from app.core.exceptions import AllDebridAPIError, DownloadError, DownloadNotFoundError
 from app.models.orm import Download, History
 from app.models.schemas import DownloadCreate, WsProgressEvent
 from app.scrapers.base import BaseScraper, get_scraper
@@ -113,28 +113,32 @@ class DownloadService:
                 if not provider_links:
                     raise DownloadError("No provider links found on the page")
 
-                _PREFERRED_PROVIDERS = ["Turbobit", "Rapidgator", "1fichier"]
-                chosen = next(
-                    (pl for name in _PREFERRED_PROVIDERS for pl in provider_links if pl.provider == name and pl.urls),
-                    next((pl for pl in provider_links if pl.urls), None),
-                )
-                if chosen is None:
-                    raise DownloadError("No usable provider link found on the page")
+                # Build ordered candidate list — preferred providers first, then the rest
+                _PREFERRED = ["Turbobit", "Rapidgator", "1fichier"]
+                preferred = [
+                    (pl.provider, url)
+                    for name in _PREFERRED
+                    for pl in provider_links
+                    if pl.provider == name
+                    for url in pl.urls
+                ]
+                others = [
+                    (pl.provider, url)
+                    for pl in provider_links
+                    if pl.provider not in _PREFERRED
+                    for url in pl.urls
+                ]
+                candidates = preferred + others
 
-                dl_protect_url = chosen.urls[0]
-                logger.info(
-                    "Download %s — provider: %s dl-protect: %s",
-                    download_id,
-                    chosen.provider,
-                    dl_protect_url,
-                )
+                if not candidates:
+                    raise DownloadError("No usable provider link found on the page")
             else:
                 # source_url is already a direct provider/dl-protect link (e.g. episode download)
-                dl_protect_url = download.source_url
                 scraper = get_scraper("wawacity")
-                logger.info("Download %s — direct provider URL: %s", download_id, dl_protect_url)
+                candidates = [("direct", download.source_url)]
+                logger.info("Download %s — direct provider URL: %s", download_id, download.source_url)
 
-            # Step 2 — resolve dl-protect intermediary to real provider URL
+            # Steps 2+3 — resolve dl-protect → debrid, with fallback on other providers
             await self._set_status(download, "resolving")
             await _emit(
                 download_id,
@@ -142,19 +146,38 @@ class DownloadService:
                     download_id=download_id, status="resolving", progress_pct=0.0
                 ).model_dump(),
             )
-            provider_url = await scraper.resolve_link(dl_protect_url)
-            logger.info("Download %s — resolved: %s", download_id, provider_url)
 
-            # Step 3 — debrid the provider link
-            await self._set_status(download, "debriding")
-            await _emit(
-                download_id,
-                WsProgressEvent(
-                    download_id=download_id, status="debriding", progress_pct=0.0
-                ).model_dump(),
-            )
+            debrid_data = None
+            last_error: Exception = DownloadError("All provider links failed")
+            for provider_name, dl_protect_url in candidates:
+                try:
+                    logger.info(
+                        "Download %s — trying provider: %s url: %s",
+                        download_id, provider_name, dl_protect_url,
+                    )
+                    provider_url = await scraper.resolve_link(dl_protect_url)
+                    logger.info("Download %s — resolved: %s", download_id, provider_url)
 
-            debrid_data = await self._alldebrid.debrid_link(provider_url)
+                    await self._set_status(download, "debriding")
+                    await _emit(
+                        download_id,
+                        WsProgressEvent(
+                            download_id=download_id, status="debriding", progress_pct=0.0
+                        ).model_dump(),
+                    )
+                    debrid_data = await self._alldebrid.debrid_link(provider_url)
+                    break
+                except AllDebridAPIError as exc:
+                    # provider_url is always defined here — error is raised after resolve_link
+                    logger.warning(
+                        "Download %s — AllDebrid rejected %s (%s): %s",
+                        download_id, provider_url, provider_name, exc,
+                    )
+                    last_error = exc
+
+            if debrid_data is None:
+                raise last_error
+
             direct_url: str | None = debrid_data.get("link") or (
                 debrid_data.get("links") or [None]
             )[0]
@@ -195,13 +218,15 @@ class DownloadService:
             await self._write_history(download, filename)
 
         except Exception as exc:
-            await self._set_status(download, "error", error=str(exc))
+            error_msg = str(exc)
+            await self._set_status(download, "error", error=error_msg)
             await _emit(
                 download_id,
                 WsProgressEvent(
                     download_id=download_id,
                     status="error",
                     progress_pct=download.progress_pct,
+                    error=error_msg,
                 ).model_dump(),
             )
             logger.exception("Download %s failed", download_id)

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -11,6 +11,11 @@ if [[ ! -f "$PROJECT_DIR/.env" ]]; then
     exit 1
 fi
 
+echo "==> Build du frontend Angular..."
+cd "$PROJECT_DIR/frontend"
+npm ci --silent
+npx ng build --configuration production
+
 echo "==> Application de la migration Alembic..."
 cd "$PROJECT_DIR/backend"
 /home/gones/.local/bin/uv run alembic upgrade head

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -11,6 +11,7 @@ graph TB
 
     subgraph Backend["⚙️ Backend FastAPI :8000"]
         direction TB
+        SPA[Fichiers statiques<br/>Angular dist/ — catch-all /*]
         API[REST API<br/>/api/v1/*]
         WS[WebSocket<br/>/ws/*]
         SVC[Services Layer<br/>search · download · alldebrid]
@@ -31,6 +32,7 @@ graph TB
     end
 
     DC -->|HTTP + aiohttp| API
+    WB -->|"GET /* — app shell + assets"| SPA
     WB -->|HTTP + Angular HttpClient| API
     WB -->|RxJS WebSocketSubject| WS
 
@@ -342,8 +344,8 @@ dl_discord_bot/                     ← monorepo racine
 │   │   │   ├── models/
 │   │   │   │   └── api.models.ts   ← interfaces TypeScript partagées
 │   │   │   └── services/
-│   │   │       ├── api.service.ts  ← HttpClient → :8000/api/v1
-│   │   │       └── ws.service.ts   ← RxJS WebSocketSubject → :8000/ws
+│   │   │       ├── api.service.ts  ← HttpClient → /api/v1 (même origin)
+│   │   │       └── ws.service.ts   ← RxJS WebSocketSubject → /ws
 │   │   ├── features/               ← lazy-loaded via loadChildren
 │   │   │   ├── search/             ← rxResource search + modal téléchargement
 │   │   │   ├── downloads/          ← linkedSignal + WS patch en temps réel
@@ -352,6 +354,7 @@ dl_discord_bot/                     ← monorepo racine
 │   │   └── shared/
 │   │       └── components/
 │   │           └── sidebar/        ← rxResource status + polling 10s
+│   ├── dist/frontend/browser/      ← build prod (ng build) servi par FastAPI
 │   └── package.json
 │
 ├── docs/
@@ -368,25 +371,22 @@ dl_discord_bot/                     ← monorepo racine
 graph TB
     subgraph docker["docker-compose.yml"]
         subgraph net["réseau interne dl_network"]
-            BE["backend<br/>:8000<br/>image: python:3.12-slim<br/>uvicorn app.main:app"]
+            BE["backend<br/>:8000<br/>image: python:3.12-slim<br/>ng build + uvicorn app.main:app<br/>(API + frontend statique)"]
             BOT["bot<br/>image: python:3.12-slim<br/>depends_on: backend"]
-            FE["frontend<br/>:80<br/>image: node + nginx<br/>ng build → nginx"]
         end
 
         V1[("volume<br/>download_path<br/>/data/media")]
         V2[("volume<br/>sqlite_db<br/>/data/db")]
     end
 
-    USER["👤 Utilisateur<br/>réseau local / VPN"] -->|:80| FE
+    USER["👤 Utilisateur<br/>réseau local / VPN"] -->|":8000 (UI + API)"| BE
     USER -->|Discord| BOT
-    FE -->|:8000| BE
     BOT -->|:8000| BE
     BE --- V1
     BE --- V2
 
     style BE fill:#009688,color:#fff
     style BOT fill:#5865F2,color:#fff
-    style FE fill:#DD0031,color:#fff
 ```
 
 > † Darkiworld : stub prévu en Phase 4, implémentation future

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -36,6 +36,10 @@ export class ApiService {
     return this.http.delete<void>(`${this.base}/downloads/${id}`);
   }
 
+  retryDownload(id: string): Observable<DownloadCreated> {
+    return this.http.post<DownloadCreated>(`${this.base}/downloads/${id}/retry`, {});
+  }
+
   getHistory(params?: {
     q?: string;
     status?: string;

--- a/frontend/src/app/features/downloads/downloads.component.html
+++ b/frontend/src/app/features/downloads/downloads.component.html
@@ -151,6 +151,15 @@
                   <span class="text-[9px] font-black ml-2" style="color:var(--lime)">100%</span>
                 }
               }
+              @if (d.status === 'error') {
+                <button (click)="retry(d.id)"
+                        class="text-[9px] font-black px-2 py-1 rounded transition"
+                        style="background:rgba(167,209,41,.08);color:#8a9a55;border:1px solid #2d3520"
+                        onmouseover="this.style.background='rgba(167,209,41,.15)';this.style.color='var(--lime)';this.style.borderColor='rgba(167,209,41,.3)'"
+                        onmouseout="this.style.background='rgba(167,209,41,.08)';this.style.color='#8a9a55';this.style.borderColor='#2d3520'">
+                  ↺ RETRY
+                </button>
+              }
               <button (click)="remove(d.id)"
                       class="w-7 h-7 rounded flex items-center justify-center transition text-xs shrink-0 ml-1"
                       style="background:transparent;border:1px solid #1a1f10;color:#3a4022"

--- a/frontend/src/app/features/downloads/downloads.component.ts
+++ b/frontend/src/app/features/downloads/downloads.component.ts
@@ -123,6 +123,12 @@ export class DownloadsComponent {
     });
   }
 
+  retry(id: string): void {
+    this.api.retryDownload(id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => this.resource.reload(),
+    });
+  }
+
   remove(id: string): void {
     this.api.cancelDownload(id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => this.downloads.update(list => list.filter(d => d.id !== id)),

--- a/frontend/src/app/features/downloads/downloads.component.ts
+++ b/frontend/src/app/features/downloads/downloads.component.ts
@@ -52,6 +52,7 @@ export class DownloadsComponent {
                   speed_mbps: event.speed_mbps ?? d.speed_mbps,
                   eta_s: event.eta_s ?? d.eta_s,
                   debrid_url: event.debrid_url ?? d.debrid_url,
+                  error: event.error ?? d.error,
                 }
               : d
           )

--- a/frontend/src/app/features/search/search.component.html
+++ b/frontend/src/app/features/search/search.component.html
@@ -128,7 +128,7 @@
           }
         </div>
         <div class="p-2">
-          <p class="text-[11px] font-bold truncate" style="color:#c8d890">{{ r.title }}</p>
+          <p class="text-[11px] font-bold leading-tight line-clamp-2" style="color:#c8d890">{{ r.title }}</p>
           <p class="text-[9px] mt-0.5" style="color:#4a5a2a">
             {{ r.language ?? '' }}{{ r.language && r.year ? ' · ' : '' }}{{ r.year ?? '' }}
           </p>

--- a/frontend/src/app/features/search/search.component.ts
+++ b/frontend/src/app/features/search/search.component.ts
@@ -1,7 +1,7 @@
 import { Component, signal, computed, linkedSignal, inject, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { EMPTY, forkJoin } from 'rxjs';
 import { ApiService } from '#core/services/api.service';
 import { CATEGORIES } from '#core/constants/media';
@@ -27,6 +27,7 @@ const PREFERRED_PROVIDERS = ['Turbobit', 'Rapidgator', '1fichier'];
 export class SearchComponent {
   private readonly api = inject(ApiService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
 
   protected query = signal('');
@@ -38,6 +39,24 @@ export class SearchComponent {
 
   // Only triggers resource when user explicitly submits
   protected searchParams = signal<SearchParams | undefined>(undefined);
+
+  constructor() {
+    // Restore state from URL query params on init
+    const p = this.route.snapshot.queryParamMap;
+    const q = p.get('q') ?? '';
+    const cat = p.get('category') ?? 'films';
+    const yr = p.get('year') ?? '';
+    const srt = p.get('sort') ?? '';
+
+    this.query.set(q);
+    this.category.set(cat);
+    this.year.set(yr);
+    this.sort.set(srt);
+
+    if (q) {
+      this.searchParams.set({ q, category: cat, year: yr || undefined, sort: srt || undefined });
+    }
+  }
 
   protected readonly searchResource = rxResource({
     params: this.searchParams,
@@ -104,11 +123,17 @@ export class SearchComponent {
   search(): void {
     const q = this.query().trim();
     if (!q) return;
-    this.searchParams.set({
+    const params: SearchParams = {
       q,
       category: this.category(),
       year: this.year() || undefined,
       sort: this.sort() || undefined,
+    };
+    this.searchParams.set(params);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { q, category: params.category, year: params.year || null, sort: params.sort || null },
+      replaceUrl: true,
     });
   }
 

--- a/frontend/src/app/features/search/search.component.ts
+++ b/frontend/src/app/features/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal, computed, linkedSignal, inject, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
+import { Component, signal, computed, linkedSignal, effect, inject, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -56,6 +56,10 @@ export class SearchComponent {
     if (q) {
       this.searchParams.set({ q, category: cat, year: yr || undefined, sort: srt || undefined });
     }
+
+    effect(() => {
+      localStorage.setItem('destination', this.selectedDestination());
+    });
   }
 
   protected readonly searchResource = rxResource({
@@ -104,7 +108,9 @@ export class SearchComponent {
   // --- Film/manga modal ---
   protected modalOpen = signal(false);
   protected selectedResult = signal<SearchResult | null>(null);
-  protected selectedDestination = signal<'server' | 'client'>('server');
+  protected selectedDestination = signal<'server' | 'client'>(
+    (localStorage.getItem('destination') as 'server' | 'client') ?? 'server'
+  );
   protected launching = signal(false);
   protected launchError = signal('');
 


### PR DESCRIPTION
## Problème

`AllDebridAPIError: This host or link is not supported` faisait échouer silencieusement le téléchargement sans retry ni message d'erreur visible immédiatement dans le frontend.

## Changements

### Backend
- **Retry sur les providers** : `download_service.py` construit maintenant une liste ordonnée de tous les candidats (providers préférés : Turbobit > Rapidgator > 1fichier, puis les autres). Si AllDebrid rejette un lien, le suivant est testé automatiquement.
- **`WsProgressEvent`** : ajout du champ `error` — le message d'erreur est propagé immédiatement via WS sans attendre le `resource.reload()`.
- **`main.py`** : le catch-all SPA exclut `/api/` et `/ws/` pour préserver le 404 natif FastAPI sur les routes API inexistantes.

### Frontend
- **`downloads.component.ts`** : patch du champ `error` depuis l'événement WS (le message s'affiche instantanément).

## Tests
- 109 tests passent (dont `test_unknown_route_returns_404` qui échouait avant le fix du catch-all).

## Test plan
- [ ] Tenter un téléchargement avec un lien dont le premier provider est rejeté par AllDebrid → vérifier le retry sur le provider suivant dans les logs
- [ ] Forcer une erreur → vérifier que le message apparaît immédiatement dans la liste Downloads sans attendre

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)