### PR TITLE
feat(frontend): sélecteur de source Wawacity / DarkiWorld

### DIFF
--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -14,8 +14,8 @@ export class ApiService {
   private readonly http = inject(HttpClient);
   private readonly base = '/api/v1';
 
-  search(query: string, category: string, year?: string, limit = 20, sort?: string, page = 1): Observable<SearchResponse> {
-    let params = new HttpParams().set('q', query).set('category', category).set('limit', limit).set('page', page);
+  search(query: string, category: string, year?: string, limit = 20, sort?: string, page = 1, source = 'wawacity'): Observable<SearchResponse> {
+    let params = new HttpParams().set('q', query).set('category', category).set('limit', limit).set('page', page).set('source', source);
     if (year) params = params.set('year', year);
     if (sort) params = params.set('sort', sort);
     return this.http.get<SearchResponse>(`${this.base}/search`, { params });

--- a/frontend/src/app/core/services/search-state.service.ts
+++ b/frontend/src/app/core/services/search-state.service.ts
@@ -11,6 +11,7 @@ export type SearchParams = {
   category: string;
   year?: string;
   sort?: string;
+  source: string;
 };
 
 @Injectable({ providedIn: 'root' })
@@ -20,7 +21,8 @@ export class SearchStateService {
   readonly query = signal('');
   readonly category = signal('films');
   readonly year = signal('');
-  readonly sort = linkedSignal<string>(() => { this.category(); return ''; });
+  readonly source = signal<string>(localStorage.getItem('dl_source') ?? 'wawacity');
+  readonly sort = linkedSignal<string>(() => { this.category(); this.source(); return ''; });
   readonly searchParams = signal<SearchParams | undefined>(undefined);
 
   private readonly settingsResource = rxResource({
@@ -94,5 +96,10 @@ export class SearchStateService {
   setDestination(value: 'server' | 'client'): void {
     this.destination.set(value);
     localStorage.setItem('dl_destination', value);
+  }
+
+  setSource(value: string): void {
+    this.source.set(value);
+    localStorage.setItem('dl_source', value);
   }
 }

--- a/frontend/src/app/features/search/search.component.html
+++ b/frontend/src/app/features/search/search.component.html
@@ -26,6 +26,17 @@
                class="w-full pl-8 pr-3 py-2 rounded text-xs bg-[#111] border border-[#1a1f10] text-[#c8d890] outline-none" />
       </div>
 
+      <!-- Source -->
+      <div class="flex rounded overflow-hidden shrink-0 text-[11px] border border-[#1a1f10]">
+        @for (s of sources; track s.value) {
+          <button class="px-3 py-2 transition font-black"
+                  [ngClass]="source() === s.value ? 'bg-[#1a1f10] text-[#c8d890]' : 'bg-transparent text-[#3a4022]'"
+                  (click)="state.setSource(s.value)">
+            {{ s.label }}
+          </button>
+        }
+      </div>
+
       <!-- Category -->
       <div class="flex rounded overflow-hidden shrink-0 text-[11px] border border-[#1a1f10]">
         @for (cat of categories; track cat) {
@@ -37,13 +48,15 @@
         }
       </div>
 
-      <!-- Sort -->
-      <select [ngModel]="sort()" (ngModelChange)="sort.set($event)"
-              class="rounded px-2.5 py-2 text-[11px] shrink-0 bg-[#111] border border-[#1a1f10] text-[#c8d890] outline-none">
-        @for (opt of sortOptions[category()]; track opt.value) {
-          <option [value]="opt.value">{{ opt.label.toUpperCase() }}</option>
-        }
-      </select>
+      <!-- Sort (Wawacity uniquement) -->
+      @if (source() === 'wawacity') {
+        <select [ngModel]="sort()" (ngModelChange)="sort.set($event)"
+                class="rounded px-2.5 py-2 text-[11px] shrink-0 bg-[#111] border border-[#1a1f10] text-[#c8d890] outline-none">
+          @for (opt of sortOptions[category()]; track opt.value) {
+            <option [value]="opt.value">{{ opt.label.toUpperCase() }}</option>
+          }
+        </select>
+      }
 
       <input type="number"
              [ngModel]="year()" (ngModelChange)="year.set($event)"

--- a/frontend/src/app/features/search/search.component.ts
+++ b/frontend/src/app/features/search/search.component.ts
@@ -31,6 +31,7 @@ export class SearchComponent {
   protected get category() { return this.state.category; }
   protected get year() { return this.state.year; }
   protected get sort() { return this.state.sort; }
+  protected get source() { return this.state.source; }
   protected get searchParams() { return this.state.searchParams; }
 
   protected readonly currentPage = signal(1);
@@ -43,7 +44,7 @@ export class SearchComponent {
       return { ...sp, page: this.currentPage() };
     },
     stream: ({ params }) =>
-      this.api.search(params.q, params.category, params.year, 20, params.sort, params.page),
+      this.api.search(params.q, params.category, params.year, 20, params.sort, params.page, params.source),
   });
 
   protected results = computed(() => this.accumulatedResults());
@@ -59,6 +60,10 @@ export class SearchComponent {
   });
 
   protected readonly categories = CATEGORIES;
+  protected readonly sources = [
+    { value: 'wawacity', label: 'WAWACITY' },
+    { value: 'darkiworld', label: 'DARKIWORLD' },
+  ];
 
   protected readonly sortOptions: Record<string, { label: string; value: string }[]> = {
     films: [
@@ -119,7 +124,7 @@ export class SearchComponent {
 
   protected readonly episodesResource = rxResource({
     params: () => this.episodePanelOpen() ? this.selectedResult() : null,
-    stream: ({ params }) => params ? this.api.getEpisodes(params.url) : EMPTY,
+    stream: ({ params }) => params ? this.api.getEpisodes(params.url, params.source) : EMPTY,
   });
 
   protected episodes = computed(() => this.episodesResource.value() ?? []);
@@ -140,6 +145,7 @@ export class SearchComponent {
       category: this.category(),
       year: this.year() || undefined,
       sort: this.sort() || undefined,
+      source: this.source(),
     });
   }
 


### PR DESCRIPTION
## Résumé

- Ajout d'un sélecteur de source (Wawacity / DarkiWorld) dans la barre de recherche
- Le filtre tri/qualité est masqué automatiquement pour DarkiWorld (non supporté côté scraper)
- Le tri se remet à zéro quand on change de source (via `linkedSignal`)
- La source choisie est persistée en localStorage
- `getEpisodes()` transmet désormais la source correcte depuis le résultat sélectionné (plus de hardcode `'wawacity'`)

## Test plan

- [ ] Sélectionner DARKIWORLD → le filtre tri/qualité disparaît
- [ ] Lancer une recherche avec DARKIWORLD → résultats proviennent bien de DarkiWorld (`source: "darkiworld"` dans les résultats)
- [ ] Lancer une recherche avec WAWACITY → filtre tri/qualité présent et fonctionnel
- [ ] Changer de source → tri reset à vide, recherche relancée si un `searchParams` existe
- [ ] Recharger la page → source persistée (localStorage `dl_source`)
- [ ] Ouvrir le panel épisodes d'une série DarkiWorld → épisodes chargés via `source=darkiworld`

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)