### PR TITLE
fix(ci): corriger les erreurs ruff bloquant le CI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,8 +10,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from sqlalchemy import func, select
 
-logger = logging.getLogger(__name__)
-
 from app.api.v1.router import router as api_v1_router
 from app.api.v1.settings import RUNTIME_SETTINGS, _runtime_value
 from app.api.ws import router as ws_router
@@ -21,6 +19,8 @@ from app.database import AsyncSessionLocal, Base, engine
 from app.models.orm import Download, History, Setting
 from app.services.download_service import DownloadService
 from app.services.notification_service import notification_scheduler
+
+logger = logging.getLogger(__name__)
 
 
 async def _run_download(download_id: str) -> None:

--- a/backend/app/scrapers/wawacity.py
+++ b/backend/app/scrapers/wawacity.py
@@ -357,7 +357,8 @@ class WawacityScraper(BaseScraper):
                 sb.js_click("#subButton")
             else:
                 logger.warning(
-                    "Button not found on page, skipping click and searching for links directly"
+                    "Button not found on page, skipping click"
+                    " and searching for links directly"
                 )
 
             # Chercher le lien résultant avec plusieurs stratégies
@@ -378,9 +379,9 @@ class WawacityScraper(BaseScraper):
             except Exception:
                 pass
 
-            # Fallback : n'importe quel lien externe sur la page (hors dl-protect lui-même)
-            # dl-protect peut rediriger vers un intermédiaire (ex: trbt.cc) au lieu d'un
-            # provider direct — AllDebrid sait résoudre ces intermédiaires.
+            # Fallback : n'importe quel lien externe sur la page
+            # (hors dl-protect lui-même) — dl-protect peut rediriger vers un
+            # intermédiaire (ex: trbt.cc) qu'AllDebrid sait résoudre.
             try:
                 all_links = sb.find_elements(By.XPATH, "//a[@href]")
                 for a in all_links:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 88
 target-version = "py312"
+exclude = ["alembic/"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]


### PR DESCRIPTION
## Problèmes

Le CI backend échouait au step **Lint (ruff)** pour 3 raisons :

1. **E402** —  défini avant les imports `app.*` dans `main.py` → déplacé après tous les imports
2. **UP035/UP007/I001** — fichiers `alembic/versions/` (auto-générés par Alembic) lintés → exclus via `exclude = ["alembic/"]` dans `pyproject.toml`
3. **E501** — deux lignes trop longues dans `wawacity.py` → wrappées

🤖 Generated with [Claude Code](https://claude.com/claude-code)