### PR TITLE
feat(docker): Docker Compose stack complète backend + bot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Python
+**/__pycache__/
+**/*.pyc
+**/.ruff_cache/
+**/.pytest_cache/
+backend/dl_bot.db
+backend/bot.log
+
+# Node / Angular
+frontend/node_modules/
+frontend/.angular/
+frontend/dist/
+
+# Bot
+bot/bot.log
+
+# Environnement
+.env
+*.env
+
+# Git / CI
+.git/
+.github/
+**/.gitignore
+
+# Docs / demo
+docs/
+demo/

--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,19 @@ REALDEBRID_API_TOKEN=your_realdebrid_api_token
 # Paths & URLs
 DOWNLOAD_PATH=/data/media
 WAWACITY_URL=https://www.wawacity.city/
+# Dev local uniquement — Docker override automatiquement avec http://backend:8000
 BACKEND_URL=http://localhost:8000
 
 # Database
+# Dev local : chemin relatif au répertoire backend/
 DATABASE_URL=sqlite+aiosqlite:///./dl_bot.db
+# Docker : décommenter la ligne suivante (chemin dans le volume backend_db)
+# DATABASE_URL=sqlite+aiosqlite:////app/data/dl_bot.db
 
 # Download queue
 MAX_CONCURRENT_DOWNLOADS=2
 
 # Selenium / dl-protect
+# Dev local : laisser vide pour utiliser le Chrome détecté automatiquement
+# Docker : géré automatiquement par l'image (SELENIUM_BINARY_LOCATION=/usr/bin/chromium)
 SELENIUM_BINARY_LOCATION=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,17 @@ cd bot
 uv run python main.py
 ```
 
+### Production (Docker Compose)
+
+```bash
+cp .env.example .env  # remplir DISCORD_TOKEN, ALLDEBRID_API_KEY, etc.
+docker compose up -d --build
+```
+
+- `BACKEND_URL` et `SELENIUM_BINARY_LOCATION` sont surchargés automatiquement par `docker-compose.yml`.
+- `DATABASE_URL` pointe vers le volume `backend_db` (`/app/data/dl_bot.db`).
+- Fichiers téléchargés dans le volume `media` (`/data/media`).
+
 ### Production (systemd)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -112,7 +112,30 @@ uv run python main.py
 
 > En développement, le proxy Angular redirige `/api` et `/ws` vers `:8000` automatiquement.
 
-### 3. Production (systemd)
+### 3. Production — Docker Compose
+
+```bash
+cp .env.example .env   # puis remplir DISCORD_TOKEN, ALLDEBRID_API_KEY, etc.
+docker compose up -d --build
+```
+
+- **`backend`** — FastAPI + Angular buildé, accessible sur `:8000`
+- **`bot`** — Discord thin client, se connecte à `backend` via le réseau interne Docker
+
+```bash
+# Voir les logs
+docker compose logs -f
+
+# Mise à jour après un pull
+docker compose up -d --build
+
+# Arrêter la stack
+docker compose down
+```
+
+> Les données sont persistées dans deux volumes Docker nommés : `media` (fichiers téléchargés) et `backend_db` (base SQLite).
+
+### 4. Production (systemd — alternative)
 
 ```bash
 bash deploy/install.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,44 @@
+# ── Stage 1 : Build Angular ──────────────────────────────────────────────────
+FROM node:22-slim AS frontend-builder
+
+WORKDIR /app/frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ .
+RUN npm run build -- --configuration production
+
+
+# ── Stage 2 : Backend Python + Chromium ──────────────────────────────────────
+FROM python:3.12-slim
+
+# Chromium requis par seleniumbase (scraping Wawacity / dl-protect)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        chromium \
+        chromium-driver \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv — gestionnaire de paquets Python
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Dépendances Python (layer caché si pyproject.toml/uv.lock inchangés)
+COPY backend/pyproject.toml backend/uv.lock ./backend/
+RUN cd backend && uv sync --frozen --no-dev
+
+# Code applicatif
+COPY backend/ ./backend/
+
+# Build Angular — FastAPI le cherche à {project_root}/frontend/dist/frontend/browser/
+COPY --from=frontend-builder /app/frontend/dist/frontend/browser/ ./frontend/dist/frontend/browser/
+
+WORKDIR /app/backend
+
+# Chromium installé via apt
+ENV SELENIUM_BINARY_LOCATION=/usr/bin/chromium
+
+EXPOSE 8000
+
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+# uv — gestionnaire de paquets Python
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app/bot
+
+# Dépendances Python
+COPY bot/pyproject.toml bot/uv.lock ./
+RUN uv sync --frozen --no-dev
+
+# Code applicatif
+COPY bot/ .
+
+# Les logs Discord vont sur stdout (StreamHandler) — le FileHandler écrit
+# bot.log dans /app/bot/bot.log ; monter un volume si persistance souhaitée.
+CMD ["uv", "run", "python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "8000:8000"
+    env_file: .env
+    environment:
+      # Chromium installé dans l'image — override l'éventuelle valeur vide du .env
+      SELENIUM_BINARY_LOCATION: /usr/bin/chromium
+      # Base de données dans un volume dédié (séparé du code applicatif)
+      DATABASE_URL: sqlite+aiosqlite:////app/data/dl_bot.db
+    volumes:
+      - media:/data/media
+      - backend_db:/app/data
+    restart: unless-stopped
+
+  bot:
+    build:
+      context: .
+      dockerfile: bot/Dockerfile
+    env_file: .env
+    environment:
+      # Résolution interne Docker — remplace http://localhost:8000 du .env
+      BACKEND_URL: http://backend:8000
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  media:
+    driver: local
+  backend_db:
+    driver: local


### PR DESCRIPTION
## Résumé

- **`backend/Dockerfile`** — multi-stage : stage 1 `node:22` build Angular, stage 2 `python:3.12-slim` + Chromium (requis par seleniumbase pour les liens dl-protect)
- **`bot/Dockerfile`** — image Python légère sans Selenium
- **`docker-compose.yml`** — services `backend` (port 8000) + `bot`, volumes nommés `media` et `backend_db`
- **`.dockerignore`** — exclut `node_modules`, `__pycache__`, `dist`, `.env`, `.git`
- **`.env.example`** — annoté avec les différences dev local / Docker
- **`README.md`** — section "Production — Docker Compose" ajoutée (étape 3)
- **`CLAUDE.md`** — section Docker Compose dans "Lancer le projet"

## Décisions techniques

- Le frontend est servi par FastAPI (pas de conteneur nginx séparé) — le build Angular est copié dans l'image backend via multi-stage
- `SELENIUM_BINARY_LOCATION=/usr/bin/chromium` surchargé dans docker-compose pour éviter que la valeur vide du `.env` écrase l'ENV du Dockerfile
- `DATABASE_URL` redirigé vers `/app/data/dl_bot.db` (volume `backend_db`) pour séparer données et code applicatif
- `BACKEND_URL=http://backend:8000` surchargé pour le bot (résolution réseau interne Docker)

## Test plan

- [ ] `docker compose up -d --build` sans erreur
- [ ] Interface accessible sur `http://localhost:8000`
- [ ] Bot Discord se connecte et répond aux commandes
- [ ] Téléchargement via dl-protect fonctionne (Selenium + Chromium)
- [ ] Données persistées après `docker compose down && docker compose up`

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)