### PR TITLE
fix: path traversal dans la destination de download (#104)

### DIFF
--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -362,25 +362,48 @@ class DownloadService:
             item = magnets
         return str(item.get("status", "")).lower()
 
+    @staticmethod
+    def _safe_component(name: str) -> str:
+        """Sanitize a path component (filename or directory).
+
+        Reduces to its basename and rejects path-traversal values. The
+        filename comes from third-party debrid data, so it must never be
+        trusted to build a path.
+        """
+        base = Path(name.strip()).name
+        if not base or base in (".", "..") or "/" in base or "\\" in base:
+            raise DownloadError(f"Unsafe filename rejected: {name!r}")
+        return base
+
     def _resolve_dest(self, media_type: str, filename: str) -> Path:
         """Return the full destination path based on media type and filename."""
         base = Path(settings.download_path)
+        filename = self._safe_component(filename)
         if media_type == "films":
-            return base / "Movies" / filename
-        if media_type in ("series", "mangas"):
-            # Try to extract show title + season from filename
-            # Pattern: ShowTitle.S01E03.anything.ext  or  ShowTitle.S01.anything.ext
+            dest = base / "Movies" / filename
+        elif media_type in ("series", "mangas"):
+            # Try to extract show title + season from filename.
+            # Accept dot- or space-separated names:
+            #   ShowTitle.S01E03.anything.ext  /  Show Title S01 anything.ext
             m = re.match(
-                r"^(.+?)\.(S\d{1,2})(?:E\d+)?(?:\.|$)",
+                r"^(.+?)[. _](S\d{1,2})(?:E\d+)?(?:[. _]|$)",
                 filename,
                 re.IGNORECASE,
             )
             if m:
-                show = m.group(1).replace(".", " ")
+                show = self._safe_component(m.group(1).replace(".", " ").strip())
                 season = m.group(2).upper()  # e.g. S01
-                return base / "Shows" / show / f"{show} - {season}" / filename
-            return base / "Shows" / filename
-        return base / filename
+                dest = base / "Shows" / show / f"{show} - {season}" / filename
+            else:
+                dest = base / "Shows" / filename
+        else:
+            dest = base / filename
+
+        # Defense in depth: ensure the resolved path stays under download_path.
+        resolved = dest.resolve()
+        if not resolved.is_relative_to(base.resolve()):
+            raise DownloadError(f"Destination escapes download path: {filename!r}")
+        return dest
 
     async def _stream_to_disk(
         self, download: Download, url: str, filename: str

--- a/backend/tests/test_download_service.py
+++ b/backend/tests/test_download_service.py
@@ -382,3 +382,58 @@ class TestRunErrors:
         refreshed = await service.get(download.id)
         assert refreshed is not None
         assert refreshed.status == "error"
+
+
+class TestResolveDest:
+    @pytest.fixture(autouse=True)
+    def _base(self, tmp_path):
+        from app.services import download_service as ds
+
+        with patch.object(ds.settings, "download_path", str(tmp_path)):
+            self.base = tmp_path
+            yield
+
+    def test_film_goes_under_movies(self, service: DownloadService) -> None:
+        dest = service._resolve_dest("films", "Cool.Movie.2024.mkv")
+        assert dest == self.base / "Movies" / "Cool.Movie.2024.mkv"
+
+    def test_series_dot_separated(self, service: DownloadService) -> None:
+        dest = service._resolve_dest("series", "Show.Name.S01E03.x264.mkv")
+        assert dest == (
+            self.base
+            / "Shows"
+            / "Show Name"
+            / "Show Name - S01"
+            / "Show.Name.S01E03.x264.mkv"
+        )
+
+    def test_series_space_separated(self, service: DownloadService) -> None:
+        dest = service._resolve_dest("series", "Show Name S01E03 x264.mkv")
+        assert dest == (
+            self.base
+            / "Shows"
+            / "Show Name"
+            / "Show Name - S01"
+            / "Show Name S01E03 x264.mkv"
+        )
+
+    @pytest.mark.parametrize(
+        ("evil", "expected_name"),
+        [
+            ("../../etc/cron.d/x", "x"),
+            ("/etc/passwd", "passwd"),
+            ("foo/../../bar", "bar"),
+            ("sub/dir/file.mkv", "file.mkv"),
+        ],
+    )
+    def test_neutralizes_path_traversal_to_basename(
+        self, service: DownloadService, evil: str, expected_name: str
+    ) -> None:
+        dest = service._resolve_dest("films", evil)
+        assert dest == self.base / "Movies" / expected_name
+        assert dest.resolve().is_relative_to(self.base.resolve())
+
+    @pytest.mark.parametrize("evil", ["..", ".", ""])
+    def test_rejects_unsafe_filename(self, service: DownloadService, evil: str) -> None:
+        with pytest.raises(DownloadError):
+            service._resolve_dest("films", evil)


### PR DESCRIPTION
## Contexte
Fix issue #104 (CRITICAL — path traversal).

`filename` provient de `debrid_data.get("filename")` ou `Path(direct_url).name` — **valeur tierce** — et était injecté sans sanitization dans le chemin de destination. Un provider compromis / MITM renvoyant `../../etc/cron.d/x` permettait d'écrire hors de `DOWNLOAD_PATH`.

## Changements
`backend/app/services/download_service.py` :
- **`_safe_component()`** : réduit au basename, rejette `""` / `.` / `..` / séparateurs (`DownloadError`).
- Sanitize du `filename` **et** du groupe `show` issu de la regex.
- **Defense in depth** : vérifie `dest.resolve().is_relative_to(download_path.resolve())` avant écriture.
- **Régression M6** : la regex saison accepte désormais les noms espace-séparés (`[. _]`), plus seulement point-séparés → arbo `Shows/<show>/<show> - S0x/` cohérente.

## Tests
`TestResolveDest` (backend/tests) :
- dest film / séries (dot- et space-separated)
- neutralisation traversal → basename, reste sous base
- rejet `.` / `..` / `""`

## Quality-gate
- `ruff format` + `ruff check` backend ✅
- `pytest` : 29 passed ✅
- `ng build --prod` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)