### PR TITLE
fix: masquer les clés API debrid dans /settings (#105)

### DIFF
--- a/backend/app/api/v1/settings.py
+++ b/backend/app/api/v1/settings.py
@@ -21,6 +21,19 @@ RUNTIME_SETTINGS = {
     "wawacity_url",
 }
 
+# Secrets never returned in clear. GET masks a non-empty value with MASK_VALUE;
+# a PUT carrying MASK_VALUE is ignored so the client round-trip can't overwrite
+# the real secret with the mask.
+SENSITIVE_KEYS = {"alldebrid_api_key", "realdebrid_api_token"}
+MASK_VALUE = "********"
+
+
+def _masked(setting: Setting) -> SettingRead:
+    value = setting.value
+    if setting.key in SENSITIVE_KEYS and value:
+        value = MASK_VALUE
+    return SettingRead(key=setting.key, value=value)
+
 
 def _runtime_value(key: str, value: str) -> str | int | bool:
     if key in ("max_concurrent_downloads", "notification_interval_hours"):
@@ -37,7 +50,7 @@ async def get_settings(
     session: AsyncSession = Depends(get_db),
 ) -> list[SettingRead]:
     result = await session.execute(select(Setting).order_by(Setting.key))
-    return [SettingRead.model_validate(s) for s in result.scalars().all()]
+    return [_masked(s) for s in result.scalars().all()]
 
 
 @router.put("/settings", response_model=list[SettingRead])
@@ -46,6 +59,9 @@ async def update_settings(
     session: AsyncSession = Depends(get_db),
 ) -> list[SettingRead]:
     for key, value in data.settings.items():
+        # Ignore a masked secret echoed back by the client: keep the stored one.
+        if key in SENSITIVE_KEYS and value == MASK_VALUE:
+            continue
         existing = await session.get(Setting, key)
         if existing is None:
             existing = Setting(key=key, value=value)
@@ -57,4 +73,4 @@ async def update_settings(
     await session.commit()
 
     result = await session.execute(select(Setting).order_by(Setting.key))
-    return [SettingRead.model_validate(s) for s in result.scalars().all()]
+    return [_masked(s) for s in result.scalars().all()]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -300,6 +300,92 @@ class TestSettings:
         assert mock_settings.debrid_provider == "realdebrid"
         assert mock_settings.max_concurrent_downloads == 3
 
+    async def test_get_masks_secret_keys(self, client) -> None:
+        await client.put(
+            "/api/v1/settings",
+            json={
+                "settings": {
+                    "alldebrid_api_key": "super-secret",
+                    "realdebrid_api_token": "tok-123",
+                }
+            },
+        )
+        resp = await client.get("/api/v1/settings")
+        values = {s["key"]: s["value"] for s in resp.json()}
+        assert values["alldebrid_api_key"] == "********"
+        assert values["realdebrid_api_token"] == "********"
+
+    async def test_put_response_masks_secret_keys(self, client) -> None:
+        resp = await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": "super-secret"}},
+        )
+        values = {s["key"]: s["value"] for s in resp.json()}
+        assert values["alldebrid_api_key"] == "********"
+
+    async def test_empty_secret_not_masked(self, client) -> None:
+        await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": ""}},
+        )
+        resp = await client.get("/api/v1/settings")
+        values = {s["key"]: s["value"] for s in resp.json()}
+        assert values["alldebrid_api_key"] == ""
+
+    async def test_put_mask_value_preserves_stored_secret(self, client) -> None:
+        await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": "real-key"}},
+        )
+        # Client echoes back the mask (e.g. user did not edit the field).
+        resp = await client.put(
+            "/api/v1/settings",
+            json={
+                "settings": {
+                    "alldebrid_api_key": "********",
+                    "wawacity_url": "https://wawa.example/",
+                }
+            },
+        )
+        assert resp.status_code == 200
+        # Stored secret untouched, masked in response.
+        values = {s["key"]: s["value"] for s in resp.json()}
+        assert values["alldebrid_api_key"] == "********"
+        assert values["wawacity_url"] == "https://wawa.example/"
+
+    async def test_mask_echo_keeps_stored_secret_in_db(
+        self, client, db_session
+    ) -> None:
+        from app.models.orm import Setting
+
+        await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": "real-key"}},
+        )
+        # Client echoes the mask back instead of the real secret.
+        await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": "********"}},
+        )
+        stored = await db_session.get(Setting, "alldebrid_api_key")
+        assert stored is not None
+        assert stored.value == "real-key"
+
+    async def test_put_changes_secret_when_not_mask(self, client, db_session) -> None:
+        from app.models.orm import Setting
+
+        await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": "old-key"}},
+        )
+        await client.put(
+            "/api/v1/settings",
+            json={"settings": {"alldebrid_api_key": "new-key"}},
+        )
+        stored = await db_session.get(Setting, "alldebrid_api_key")
+        assert stored is not None
+        assert stored.value == "new-key"
+
 
 # ---------------------------------------------------------------------------
 # Status


### PR DESCRIPTION
## Contexte
Fix issue #105 (CRITICAL — exposition de secrets).

`GET /api/v1/settings` renvoyait **toutes** les `Setting` en clair, dont `alldebrid_api_key` et `realdebrid_api_token`, sans authentification. Quiconque atteint `:8000` / `:8765` lisait (et pouvait écraser) les credentials debrid.

## Changements
`backend/app/api/v1/settings.py` :
- `SENSITIVE_KEYS = {alldebrid_api_key, realdebrid_api_token}`, masque `MASK_VALUE = "********"`.
- Helper `_masked()` : remplace une valeur sensible **non vide** par `********` dans les réponses **GET et PUT**.
- **Garde round-trip** : un `PUT` portant `********` pour une clé sensible est ignoré → le secret stocké n'est pas écrasé par le masque renvoyé par le client.
- Secret vide → non masqué (champ vide reste vide, permet de clear).

## Frontend
Aucun changement nécessaire : le champ recharge `********` et le renvoie tel quel au save → préservé par la garde PUT. Pour changer la clé, l'utilisateur tape une nouvelle valeur (≠ masque) → persistée.

## Tests (`tests/test_api.py::TestSettings`)
- GET et PUT masquent les clés sensibles
- secret vide non masqué
- echo du masque préserve le secret stocké (vérifié en DB)
- nouvelle valeur ≠ masque bien persistée (vérifié en DB)

## Quality-gate
- `ruff format` + `ruff check` ✅
- `pytest` : 136 passed ✅

> Note : masquage seul, pas d'auth. Une couche d'auth (issue dédiée) reste recommandée comme indiqué dans #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)