### PR TITLE
fix: ranger séries au nommage français (saison N) dans des sous-dossiers

### DIFF
--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -383,16 +383,18 @@ class DownloadService:
             dest = base / "Movies" / filename
         elif media_type in ("series", "mangas"):
             # Try to extract show title + season from filename.
-            # Accept dot- or space-separated names:
+            # Accept dot- or space-separated names, English or French:
             #   ShowTitle.S01E03.anything.ext  /  Show Title S01 anything.ext
+            #   Show saison 1 ep1.ext          /  Show.Saison.1.Episode.3.ext
             m = re.match(
-                r"^(.+?)[. _](S\d{1,2})(?:E\d+)?(?:[. _]|$)",
+                r"^(.+?)[. _-]+(?:S(\d{1,2})|saison[. _]*(\d{1,2}))",
                 filename,
                 re.IGNORECASE,
             )
             if m:
                 show = self._safe_component(m.group(1).replace(".", " ").strip())
-                season = m.group(2).upper()  # e.g. S01
+                num = int(m.group(2) or m.group(3))
+                season = f"S{num:02d}"  # e.g. S01
                 dest = base / "Shows" / show / f"{show} - {season}" / filename
             else:
                 dest = base / "Shows" / filename


### PR DESCRIPTION
## Problème

Série téléchargée (`Smallville saison 1 ep1-Wawacity.ec.avi`) déposée à plat dans `Shows/` au lieu de `Shows/Smallville/Smallville - S01/`.

Cause : le regex de `_resolve_dest` n'acceptait que le format `SxxExx`. Les nommages français (`saison 1 ep1`) tombaient dans le fallback sans sous-dossier.

## Fix

Regex étendu pour accepter :
- anglais : `S01`, `S01E03`
- français : `saison 1`, `Saison.10`
- séparateurs `.` `_` `-` espace
- saisons normalisées en `SXX` (padding 2 chiffres)

Testé sur Ghosts, Smallville, Dexter, Mr Robot, The Boys.

⚠️ Affecte seulement les **nouveaux** téléchargements. Fichiers déjà à plat à déplacer manuellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)