### PR TITLE
fix: renommer épisodes séries au format SxxEyy pour Jellyfin

### DIFF
--- a/backend/app/services/download_service.py
+++ b/backend/app/services/download_service.py
@@ -375,6 +375,32 @@ class DownloadService:
             raise DownloadError(f"Unsafe filename rejected: {name!r}")
         return base
 
+    @staticmethod
+    def _jellyfin_episode_name(filename: str, show: str, season: int) -> str:
+        """Rename a series file to the ``Show SxxEyy.ext`` form Jellyfin needs.
+
+        Jellyfin only detects episodes whose filename contains ``SxxEyy``.
+        French source names such as ``Show saison 1 ep1.avi`` are ignored,
+        leaving the episode invisible in the library. When the episode number
+        can be parsed, rebuild the name; otherwise keep the original filename.
+        """
+        # Already in SxxEyy form: leave it untouched so quality tags and the
+        # original release name are preserved.
+        if re.search(r"S\d{1,2}[. _-]*E\d{1,3}", filename, re.IGNORECASE):
+            return filename
+        # French source names ("... ep1", "... Episode 3") are invisible to
+        # Jellyfin; rebuild them when an episode number can be parsed.
+        em = re.search(
+            r"(?:^|[. _-])(?:episode|ep)[. _]*(\d{1,3})",
+            filename,
+            re.IGNORECASE,
+        )
+        if not em:
+            return filename
+        episode = int(em.group(1))
+        ext = Path(filename).suffix
+        return f"{show} S{season:02d}E{episode:02d}{ext}"
+
     def _resolve_dest(self, media_type: str, filename: str) -> Path:
         """Return the full destination path based on media type and filename."""
         base = Path(settings.download_path)
@@ -395,6 +421,7 @@ class DownloadService:
                 show = self._safe_component(m.group(1).replace(".", " ").strip())
                 num = int(m.group(2) or m.group(3))
                 season = f"S{num:02d}"  # e.g. S01
+                filename = self._jellyfin_episode_name(filename, show, num)
                 dest = base / "Shows" / show / f"{show} - {season}" / filename
             else:
                 dest = base / "Shows" / filename

--- a/backend/tests/test_download_service.py
+++ b/backend/tests/test_download_service.py
@@ -417,6 +417,22 @@ class TestResolveDest:
             / "Show Name S01E03 x264.mkv"
         )
 
+    def test_series_french_naming_renamed_to_sxxeyy(
+        self, service: DownloadService
+    ) -> None:
+        # French source names ("saison 1 ep1") are invisible to Jellyfin and
+        # must be rebuilt to the SxxEyy form it can detect.
+        dest = service._resolve_dest(
+            "series", "Smallville saison 1 ep1-Wawacity.ec.avi"
+        )
+        assert dest == (
+            self.base
+            / "Shows"
+            / "Smallville"
+            / "Smallville - S01"
+            / "Smallville S01E01.avi"
+        )
+
     @pytest.mark.parametrize(
         ("evil", "expected_name"),
         [


### PR DESCRIPTION
## Problème

Les noms de fichiers français issus de Wawacity (`Show saison 1 ep1.avi`) ne sont pas reconnus comme épisodes par Jellyfin, qui exige le motif `SxxEyy`. Résultat : épisodes invisibles dans la médiathèque (ex: `Smallville saison 1 ep1-Wawacity.ec.avi`).

## Correctif

`_resolve_dest` reconstruit le nom de fichier en `{Show} S{ss}E{ee}{ext}` quand le numéro d'épisode est parsable (`ep1`, `Episode 3`, …).

- Noms déjà au format `SxxEyy` → **laissés intacts** (préserve tags qualité / nom de release).
- Numéro d'épisode non parsable → fallback sur nom original.
- N'affecte que les **futurs** téléchargements ; fichiers existants à renommer manuellement.

## Tests

- Nouveau test `test_series_french_naming_renamed_to_sxxeyy`.
- Suite complète : 137 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)